### PR TITLE
Change cloneWithProps to React.cloneElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react"
     ]
+  },
+  "dependencies": {
+    "classnames": "^2.1.3"
   }
 }

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,8 +1,7 @@
 var React = require('react'),
-    joinClasses = require('react/lib/joinClasses'),
-    constants = require('./constants');
+    constants = require('./constants'),
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Button = React.createClass({
   propTypes: {
     node: React.PropTypes.node,
@@ -28,17 +27,6 @@ var Button = React.createClass({
     });
     return (
       <C {...this.props} className={cx(classes)}>
-        {this.props.children}
-      </C>
-    );
-  },
-  renderAnchor(classes) {
-    var C = this.props.node || 'a';
-    var href = this.props.href || '#';
-    return (
-      <C {...this.props}
-        href={href}
-        className={cx(classes)}>
         {this.props.children}
       </C>
     );

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,7 +1,5 @@
 var React = require('react'),
-    joinClasses = require('react/lib/joinClasses');
-
-var cx = React.addons.classSet;
+    cx = require('classnames');
 
 var Card = React.createClass({
   propTypes: {
@@ -14,9 +12,9 @@ var Card = React.createClass({
     var classes = { card: true };
     return (
       <div {...props}
-        className={joinClasses(className, cx(classes))} >
+        className={cx(className, classes)} >
         {header}
-        <div className={joinClasses('card-content', textClassName)}>
+        <div className={cx('card-content', textClassName)}>
           {title ? this.renderTitle(title) : null}
           <p>{children}</p>
         </div>

--- a/src/CardTitle.js
+++ b/src/CardTitle.js
@@ -1,6 +1,5 @@
 var React = require('react'),
-    cx = React.addons.classSet,
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
 var CardTitle = React.createClass({
   propTypes: {

--- a/src/Col.js
+++ b/src/Col.js
@@ -1,7 +1,6 @@
 var React = require('react/addons'),
-    constants = require('./constants');
-
-var cx = React.addons.classSet;
+    constants = require('./constants'),
+    cx = require('classnames');
 
 var Col = React.createClass({
   propTypes: {

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,8 +1,7 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses'),
-    cloneWithProps = require('react/lib/cloneWithProps');
+    cloneWithProps = require('react/lib/cloneWithProps'),
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Collapsible = React.createClass({
   propTypes: {
     accordion: React.PropTypes.bool.isRequired
@@ -22,7 +21,7 @@ var Collapsible = React.createClass({
       accordion
     };
     return (
-      <ul className={joinClasses(className, cx(classes))} {...props}>
+      <ul className={cx(className, classes)} {...props}>
         {React.Children.map(children, this.renderItem)}
       </ul>
     );

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,5 +1,4 @@
 var React = require('react/addons'),
-    cloneWithProps = require('react/lib/cloneWithProps'),
     cx = require('classnames');
 
 var Collapsible = React.createClass({
@@ -37,7 +36,7 @@ var Collapsible = React.createClass({
       props.onSelect = this.handleSelect;
     }
 
-    return cloneWithProps(child, props);
+    return React.cloneElement(child, props);
   },
 
   handleSelect(key) {

--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -1,8 +1,7 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses'),
-    Icon = require('./Icon');
+    Icon = require('./Icon'),
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var CollapsibleItem = React.createClass({
   propTypes: {
     header: React.PropTypes.string.isRequired,

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -1,7 +1,6 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Collection = React.createClass({
   propTypes: {
     header: React.PropTypes.node

--- a/src/CollectionItem.js
+++ b/src/CollectionItem.js
@@ -1,7 +1,6 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var CollectionItem = React.createClass({
   propTypes: {
     active: React.PropTypes.bool,

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -1,7 +1,7 @@
 var React = require('react/addons'),
-    constants = require('./constants');
+    constants = require('./constants'),
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Icon = React.createClass({
   propTypes: {
     placement: React.PropTypes.oneOf(['left', 'right']),

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,7 +1,7 @@
 var React = require('react/addons'),
-    constants = require('./constants');
+    constants = require('./constants'),
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Input = React.createClass({
   propTypes: {
     s: React.PropTypes.number,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,8 +1,6 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses'),
-    Button = require('./Button');
-
-var cx = React.addons.classSet;
+    Button = require('./Button'),
+    cx = require('classnames');
 
 var Modal = React.createClass({
   propTypes: {

--- a/src/ModalTrigger.js
+++ b/src/ModalTrigger.js
@@ -1,5 +1,4 @@
 var React = require('react/addons'),
-    cloneWithProps = require('react/lib/cloneWithProps'),
     Overlay = require('./Overlay');
 
 export default class ModalTrigger extends Overlay {
@@ -14,7 +13,7 @@ export default class ModalTrigger extends Overlay {
 
   render() {
     var child = React.Children.only(this.props.children);
-    return cloneWithProps(child, {onClick: this.toggle});
+    return React.cloneElement(child, {onClick: this.toggle});
   }
 
   toggle() {
@@ -29,10 +28,4 @@ export default class ModalTrigger extends Overlay {
     });
   }
 
-  renderOverlay() {
-    if (!this.state.isOverlayShown) {
-      return <span />;
-    }
-    return cloneWithProps(this.props.modal, {onRequestHide: this.hide});
-  }
 }

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,6 +1,6 @@
 var React = require('react'),
-    joinClasses = require('react/lib/joinClasses');
-var cx = React.addons.classSet;
+    cx = require('classnames');
+
 var NavItem = React.createClass({
   propTypes: {
     href: React.PropTypes.string

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,8 +1,7 @@
 var React = require('react/addons'),
     Col = require('./Col'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Navbar = React.createClass({
   propTypes: {
     brand: React.PropTypes.node,
@@ -26,7 +25,7 @@ var Navbar = React.createClass({
               data-activates='nav-mobile'>
               <i className='mdi-navigation-menu'></i>
             </a>
-            <ul className={joinClasses(className, cx(classes))}>
+            <ul className={cx(className, classes)}>
               {this.props.children}
             </ul>
           </Col>

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -1,5 +1,4 @@
 var React = require('react'),
-    joinClasses = require('react/lib/joinClasses'),
     cloneWithProps = require('react/lib/cloneWithProps'),
     Overlay = require('./Overlay');
 

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -1,5 +1,4 @@
 var React = require('react'),
-    cloneWithProps = require('react/lib/cloneWithProps'),
     Overlay = require('./Overlay');
 
 export default class OverlayTrigger extends Overlay {
@@ -16,7 +15,7 @@ export default class OverlayTrigger extends Overlay {
   render() {
     var {overlay, children, ...props} = this.props;
     var child = React.Children.only(children);
-    return cloneWithProps(
+    return React.cloneElement(
       child,
       {onClick: this.toggle}
     );

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,14 +1,13 @@
 var React = require('react'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Panel = React.createClass({
   render() {
     var classes = {
       'card-panel': true
     };
     return (
-      <div className={joinClasses(this.props.className, cx(classes))}
+      <div className={cx(this.props.className, classes)}
         {...this.props}>
         {this.props.children}
       </div>

--- a/src/Preloader.js
+++ b/src/Preloader.js
@@ -1,7 +1,7 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses'),
-    constants = require('./constants');
-var cx = React.addons.classSet;
+    constants = require('./constants'),
+    cx = require('classnames');
+
 var Preloader = React.createClass({
   propTypes: {
     size: React.PropTypes.oneOf(constants.SCALES),
@@ -25,7 +25,7 @@ var Preloader = React.createClass({
       classes[this.props.size] = true;
     }
     return (
-      <div className={joinClasses(this.props.className, cx(classes))}>
+      <div className={cx(this.props.className, classes)}>
         {this.props.colors.map(color => {
           var spinnerClasses = {
             'spinner-layer': true

--- a/src/Row.js
+++ b/src/Row.js
@@ -1,5 +1,5 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
 var Row = React.createClass({
   propTypes: {
@@ -13,7 +13,7 @@ var Row = React.createClass({
   render() {
     var C = this.props.node;
     return (
-      <C className={joinClasses('row', this.props.className)}
+      <C className={cx('row', this.props.className)}
         {...this.props}>
         {this.props.children}
       </C>

--- a/src/TabArea.js
+++ b/src/TabArea.js
@@ -1,7 +1,6 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var TabArea = React.createClass({
   render() {
     return (

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,7 +1,6 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Table = React.createClass({
   propTypes: {
     centered: React.PropTypes.bool,
@@ -17,7 +16,7 @@ var Table = React.createClass({
       bordered: this.props.bordered
     };
     return (
-      <table className={joinClasses(this.props.className, cx(classes))} {...this.props}>
+      <table className={cx(this.props.className, classes)} {...this.props}>
         {this.props.children}
       </table>
     );

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -1,7 +1,6 @@
 var React = require('react/addons'),
-    joinClasses = require('react/lib/joinClasses');
+    cx = require('classnames');
 
-var cx = React.addons.classSet;
 var Toast = React.createClass({
   propTypes: {
     rounded: React.PropTypes.bool
@@ -18,7 +17,7 @@ var Toast = React.createClass({
     };
     var {className, children, ...props} = this.props;
     return (
-      <div className={joinClasses(className, cx(classes))} style={style}>
+      <div className={cx(className, classes)} style={style}>
         <span>
           {children}
         </span>

--- a/src/__tests__/Button-test.js
+++ b/src/__tests__/Button-test.js
@@ -2,6 +2,8 @@
 
 jest.dontMock('../Button');
 jest.dontMock('../constants');
+jest.dontMock('classnames');
+
 describe('Button', function() {
   var React = require('react/addons'),
       TestUtils = React.addons.TestUtils,

--- a/src/__tests__/Card-test.js
+++ b/src/__tests__/Card-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../Card');
 jest.dontMock('../CardTitle');
+jest.dontMock('classnames');
 
 describe('Card', function() {
   var React = require('react/addons'),

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../Collection');
 jest.dontMock('../CollectionItem');
+jest.dontMock('classnames');
 
 describe('Collection', function() {
   var React = require('react/addons'),

--- a/src/__tests__/Panel-test.js
+++ b/src/__tests__/Panel-test.js
@@ -1,4 +1,5 @@
 jest.dontMock('../Panel');
+jest.dontMock('classnames');
 
 describe('Panel', function() {
   var React = require('react/addons'),


### PR DESCRIPTION
The lib function [cloneWithProps](https://facebook.github.io/react/docs/clone-with-props.html) is deprecated, updated to [React.cloneElement](https://facebook.github.io/react/docs/clone-with-props.html).

Note this also includes the changes from my earlier [pull request](https://github.com/react-materialize/react-materialize/pull/8).