### PR TITLE
Input labels adjustment

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -4,6 +4,10 @@ import cx from 'classnames';
 import uuid from 'node-uuid';
 
 class Input extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {hasValue: false};
+  }
   componentDidMount() {
     this._setupEl();
   }
@@ -20,12 +24,13 @@ class Input extends React.Component {
         $inputEl.material_select();
       }
       else {
-        var $labelEl = $(this.refs.labelEl);
-        if ($inputEl.val()) {
-          $labelEl.addClass('active');
-        }
-        else {
-          $labelEl.removeClass('active');
+        var previousHasValue = this.state.hasValue;
+        var actualHasValue = !!$inputEl.val();
+
+        if (previousHasValue !== actualHasValue) {
+          this.setState({
+            hasValue: actualHasValue
+          });
         }
       }
     }
@@ -66,7 +71,10 @@ class Input extends React.Component {
         C = 'input';
         inputType = type || 'text';
     }
-    let htmlLabel = <label ref="labelEl" htmlFor={id}>{label}</label>;
+    let labelClasses = {
+      active: this.state.hasValue
+    };
+    let htmlLabel = <label className={cx(labelClasses)} htmlFor={id}>{label}</label>;
     return (
       <div className={cx(classes)}>
         {this.props.type === 'select' && this.props.browserDefault ? htmlLabel : null}

--- a/src/Input.js
+++ b/src/Input.js
@@ -35,7 +35,7 @@ class Input extends React.Component {
   render() {
     let classes = {
       col: true,
-      'input-field': true
+      'input-field': this.props.type !== 'checkbox' && this.props.type !== 'radio'
     };
     let {placeholder, id, type, label, ...props} = this.props;
     constants.SIZES.forEach(size => {

--- a/src/Input.js
+++ b/src/Input.js
@@ -6,16 +6,29 @@ import uuid from 'node-uuid';
 
 class Input extends React.Component {
   componentDidMount() {
-    if (this.props.type === 'select' && !this.props.browserDefault && typeof $ !== 'undefined') {
-      $(ReactDOM.findDOMNode(this.refs.inputEl)).material_select();
-    }
+    this._setupEl();
+  }
+  componentDidUpdate() {
+    this._setupEl();
   }
 
-  componentDidUpdate() {
-    if (this.props.type === 'select' && !this.props.browserDefault && typeof $ !== 'undefined') {
-      var $el = $(ReactDOM.findDOMNode(this.refs.inputEl));
-      $el.material_select('destroy');
-      $el.material_select();
+  _setupEl() {
+    if (typeof $ !== 'undefined') {
+      var $inputEl = $(ReactDOM.findDOMNode(this.refs.inputEl));
+
+      if (this.props.type === 'select' && !this.props.browserDefault) {
+        $inputEl.material_select('destroy');
+        $inputEl.material_select();
+      }
+      else {
+        var $labelEl = $(ReactDOM.findDOMNode(this.refs.labelEl));
+        if ($inputEl.val()) {
+          $labelEl.addClass('active');
+        }
+        else {
+          $labelEl.removeClass('active');
+        }
+      }
     }
   }
 
@@ -54,7 +67,7 @@ class Input extends React.Component {
         C = 'input';
         inputType = type || 'text';
     }
-    let htmlLabel = <label htmlFor={id}>{label}</label>;
+    let htmlLabel = <label ref="labelEl" htmlFor={id}>{label}</label>;
     return (
       <div className={cx(classes)}>
         {this.props.type === 'select' && this.props.browserDefault ? htmlLabel : null}

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import constants from './constants';
 import cx from 'classnames';
 import uuid from 'node-uuid';
@@ -14,14 +13,14 @@ class Input extends React.Component {
 
   _setupEl() {
     if (typeof $ !== 'undefined') {
-      var $inputEl = $(ReactDOM.findDOMNode(this.refs.inputEl));
+      var $inputEl = $(this.refs.inputEl);
 
       if (this.props.type === 'select' && !this.props.browserDefault) {
         $inputEl.material_select('destroy');
         $inputEl.material_select();
       }
       else {
-        var $labelEl = $(ReactDOM.findDOMNode(this.refs.labelEl));
+        var $labelEl = $(this.refs.labelEl);
         if ($inputEl.val()) {
           $labelEl.addClass('active');
         }


### PR DESCRIPTION
Adjusted the `<label>` element in `Input` …

For more info, see the [forms documentation of materializecss](http://materializecss.com/forms.html#!),
specifically in the "Prefilling Text Inputs" section.

Also fixed labels for radio and checkbox inputs, where the `input-field` class was messing with label placement. materializecss' website shows the checkbox/radio examples without that class.

@isaiah awaiting your comments.