### PR TITLE
Remove <p>-tag around {children} in Modals.js

### DIFF
--- a/examples/Modal.js
+++ b/examples/Modal.js
@@ -6,7 +6,7 @@ import Button from '../src/Button';
 export default
 <OverlayTrigger overlay={
   <Modal header='Modal Header'>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
   </Modal>
 }>
   <Button waves='light'>MODAL</Button>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -16,7 +16,7 @@ class Modal extends React.Component {
       <div className={cx(classes)} {...props}>
         <div className="modal-content">
           <h4>{header}</h4>
-          <p>{children}</p>
+          {children}
         </div>
         <div className="modal-footer">
           <Button waves='light' modal='close' flat>Close</Button>


### PR DESCRIPTION
You don't always want text in a modal. For instance I had issues when using a form in modals with the paragraph wrapper.