### PR TITLE
change select input to re-materialize selects on update

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -12,9 +12,21 @@ class Input extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.type === 'select' && !this.props.browserDefault && typeof $ !== 'undefined') {
+    if (this.isMaterialSelect()) {
       $(this.refs.inputEl).material_select();
       $(this.refs.inputEl).on('change', this._onChange);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.isMaterialSelect()) {
+      $(this.refs.inputEl).material_select();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.isMaterialSelect()) {
+      $(this.refs.inputEl).off('change', this._onChange);
     }
   }
 
@@ -120,6 +132,10 @@ class Input extends React.Component {
 
   isSelect() {
     return this.props.type === 'select';
+  }
+
+  isMaterialSelect() {
+    this.props.type === 'select' && !this.props.browserDefault && typeof $ !== 'undefined';
   }
 }
 


### PR DESCRIPTION
I was noticing an issue where if I changed the options passed into an `Input type='select'`, the underlying select would change but the wrapper would still display the old items. This should fix that, also off'd the listened for onChange, but let me know if that shouldn't be done.

Thanks!