### PR TITLE
Put children for card in a div.

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -17,7 +17,7 @@ class Card extends React.Component {
         {header}
         <div className={cx('card-content', textClassName)}>
           {title ? this.renderTitle(title, reveal) : null}
-          <p>{children}</p>
+          <div>{children}</div>
         </div>
         {this.renderReveal(title, reveal)}
         {actions ? this.renderAction(actions) : null}


### PR DESCRIPTION
Currently if you try to put something like a table in the body of a card, you get a DOM validation warning from React because a table cannot be a descendant of a p tag.

This change will keep the card from restricting what the contents of the card can be.