### PR TITLE
Add onChange listener to switch inputs

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -108,7 +108,12 @@ class Input extends React.Component {
         <div className="switch">
           <label>
             Off
-            <input type="checkbox" name={this.props.name} {...props} />
+            <input
+              name={this.props.name}
+              onChange={this._onChange}
+              type="checkbox"
+              {...props}
+            />
             <span className="lever"></span>
             On
           </label>


### PR DESCRIPTION
Input `switch` type was missing the onChange listener.

Thanks to @linuxenko