### PR TITLE
Fix to renderBody

### DIFF
--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -43,7 +43,7 @@ class CollapsibleItem extends React.Component {
   }
 
   renderBody() {
-    if (!this.state.expanded) return;
+    if (!this.state.expanded && !this.props.expanded) return;
 
     const style = {display: 'block'};
     return (


### PR DESCRIPTION
Render body need to conside props.expaned, setted in Colllapsible component this:

```
if (this.props.accordion) {
  props.expanded = child.props.eventKey === this.state.activeKey;
  props.onSelect = this.handleSelect;
}

return React.cloneElement(child, props);
```
