### PR TITLE
adding ref and focus method to Input component

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -4,188 +4,188 @@ import idgen from './idgen';
 import constants from './constants';
 
 class Input extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {value: this.props.defaultValue};
-    this._onChange = this._onChange.bind(this);
-    this.isSelect = this.isSelect.bind(this);
-    this.focus = this.focus.bind(this);
-  }
-
-  componentDidMount() {
-    if (this.isMaterialSelect()) {
-      $(this.selectInput).material_select();
-      $(this.selectInput).on('change', this._onChange);
+    constructor(props) {
+        super(props);
+        this.state = {value: this.props.defaultValue};
+        this._onChange = this._onChange.bind(this);
+        this.isSelect = this.isSelect.bind(this);
+        this.focus = this.focus.bind(this);
     }
-  }
 
-  componentDidUpdate() {
-    if (this.isMaterialSelect()) {
-      $(this.selectInput).material_select();
+    componentDidMount() {
+        if (this.isMaterialSelect()) {
+            $(this.selectInput).material_select();
+            $(this.selectInput).on('change', this._onChange);
+        }
     }
-  }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.isMaterialSelect()) {
-      this.setState({
-        value: nextProps.defaultValue
-      }, () => $(this.selectInput).material_select());
+    componentDidUpdate() {
+        if (this.isMaterialSelect()) {
+            $(this.selectInput).material_select();
+        }
     }
-  }
 
-  componentWillUnmount() {
-    if (this.isMaterialSelect()) {
-      $(this.selectInput).off('change', this._onChange);
+    componentWillReceiveProps(nextProps) {
+        if (this.isMaterialSelect()) {
+            this.setState({
+                value: nextProps.defaultValue
+            }, () => $(this.selectInput).material_select());
+        }
     }
-  }
 
-  _onChange(e) {
-    this.setState({
-      value: e.target.type === 'checkbox' ? e.target.checked : e.target.value
-    });
-
-    if (this.props.onChange) {
-      this.props.onChange(e);
+    componentWillUnmount() {
+        if (this.isMaterialSelect()) {
+            $(this.selectInput).off('change', this._onChange);
+        }
     }
-  }
 
-  focus() {
-  	this.input.focus();
-  }
+    _onChange(e) {
+        this.setState({
+            value: e.target.type === 'checkbox' ? e.target.checked : e.target.value
+        });
 
-  render() {
-    let { defaultValue, placeholder, id, type, label, children, validate, ...props} = this.props;
-    let classes = {
-      col: true,
-      'input-field': type !== 'checkbox' && type !== 'radio'
-    };
-    constants.SIZES.forEach(size => {
-      if (this.props[size]) {
-        classes[size + this.props[size]] = true;
-      }
-    });
-    if (!id) {
-      id = `input_${idgen()}`;
+        if (this.props.onChange) {
+            this.props.onChange(e);
+        }
     }
-    let inputClasses = {
-      validate,
-      'browser-default' : !!this.props.browserDefault && this.isSelect()
-    };
-    let C, inputType;
-    switch (type) {
-    case 'textarea':
-      C = 'textarea';
-      inputClasses['materialize-textarea'] = true;
-      break;
-    case 'switch':
-      C = 'input';
-      inputType = 'checkbox';
-      break;
-    default:
-      C = 'input';
-      inputType = type || 'text';
+
+    focus() {
+        this.input.focus();
     }
-    let labelClasses = {
-      active: this.state.value || this.isSelect()
-    };
 
-    let htmlLabel = label || inputType === 'radio' ? <label className={cx(labelClasses)} htmlFor={id}>{label}</label> : null;
+    render() {
+        let { defaultValue, placeholder, id, type, label, children, validate, ...props} = this.props;
+        let classes = {
+            col: true,
+            'input-field': type !== 'checkbox' && type !== 'radio'
+        };
+        constants.SIZES.forEach(size => {
+            if (this.props[size]) {
+                classes[size + this.props[size]] = true;
+            }
+        });
+        if (!id) {
+            id = `input_${idgen()}`;
+        }
+        let inputClasses = {
+            validate,
+            'browser-default' : !!this.props.browserDefault && this.isSelect()
+        };
+        let C, inputType;
+        switch (type) {
+            case 'textarea':
+            C = 'textarea';
+            inputClasses['materialize-textarea'] = true;
+            break;
+            case 'switch':
+            C = 'input';
+            inputType = 'checkbox';
+            break;
+            default:
+            C = 'input';
+            inputType = type || 'text';
+        }
+        let labelClasses = {
+            active: this.state.value || this.isSelect()
+        };
 
-    if (this.isSelect()) {
-      let options = placeholder && !defaultValue ? [<option disabled key={idgen()}>{placeholder}</option>] : [];
-      options = options.concat(React.Children.map(children, (child) => {
-        return React.cloneElement(child, {'key': child.props.value});
-      }));
-      return (
-        <div className={cx(classes)}>
-          {htmlLabel}
-          <select
-            id={id}
-            className={cx(inputClasses)}
-            ref={(ref) => this.selectInput = ref}
-            defaultValue={defaultValue}
-            {...props}
-          >
-            { options }
-          </select>
-        </div>
-      );
-    } else if (type === 'switch') {
-      return (
-        <div className="switch">
-          <label>
-            Off
-            <input
-              name={this.props.name}
-              onChange={this._onChange}
-              type="checkbox"
-              {...props}
-            />
-            <span className="lever"></span>
-            On
-          </label>
-        </div>
-      );
+        let htmlLabel = label || inputType === 'radio' ? <label className={cx(labelClasses)} htmlFor={id}>{label}</label> : null;
+
+        if (this.isSelect()) {
+            let options = placeholder && !defaultValue ? [<option disabled key={idgen()}>{placeholder}</option>] : [];
+            options = options.concat(React.Children.map(children, (child) => {
+                return React.cloneElement(child, {'key': child.props.value});
+            }));
+            return (
+                <div className={cx(classes)}>
+                    {htmlLabel}
+                    <select
+                        id={id}
+                        className={cx(inputClasses)}
+                        ref={(ref) => this.selectInput = ref}
+                        defaultValue={defaultValue}
+                        {...props}
+                        >
+                        { options }
+                    </select>
+                </div>
+            );
+        } else if (type === 'switch') {
+            return (
+                <div className="switch">
+                    <label>
+                        Off
+                        <input
+                            name={this.props.name}
+                            onChange={this._onChange}
+                            type="checkbox"
+                            {...props}
+                            />
+                        <span className="lever"></span>
+                        On
+                    </label>
+                </div>
+            );
+        }
+        else {
+            let icon = null;
+            if (React.Children.count(children) == 1) {
+                icon = React.Children.only(children);
+            }
+
+            switch(inputType) {
+                case 'checkbox':
+                break;
+                case 'radio':
+                break;
+                default:
+                props.defaultValue = this.state.value;
+            }
+
+            return (
+                <div className={cx(classes)}>
+                    {icon === null ? null : React.cloneElement(icon, {className: 'prefix'})}
+                    <C
+                        id={id}
+                        className={cx(inputClasses)}
+                        onChange={this._onChange}
+                        placeholder={placeholder}
+                        type={inputType}
+                        ref={ref => {this.input = ref;}}
+                        {...props}
+                        />
+                    {htmlLabel}
+                </div>
+            );
+        }
     }
-    else {
-      let icon = null;
-      if (React.Children.count(children) == 1) {
-        icon = React.Children.only(children);
-      }
 
-      switch(inputType) {
-      case 'checkbox':
-        break;
-      case 'radio':
-        break;
-      default:
-        props.defaultValue = this.state.value;
-      }
-
-      return (
-        <div className={cx(classes)}>
-            {icon === null ? null : React.cloneElement(icon, {className: 'prefix'})}
-            <C
-                id={id}
-                className={cx(inputClasses)}
-                onChange={this._onChange}
-                placeholder={placeholder}
-                type={inputType}
-                ref={ref => {this.input = ref;}}
-                {...props}
-            />
-            {htmlLabel}
-        </div>
-      );
+    isSelect() {
+        return this.props.type === 'select';
     }
-  }
 
-  isSelect() {
-    return this.props.type === 'select';
-  }
-
-  isMaterialSelect() {
-    return this.props.type === 'select' && !this.props.browserDefault && typeof $ !== 'undefined';
-  }
+    isMaterialSelect() {
+        return this.props.type === 'select' && !this.props.browserDefault && typeof $ !== 'undefined';
+    }
 }
 
 Input.propTypes = {
-  s: React.PropTypes.number,
-  m: React.PropTypes.number,
-  l: React.PropTypes.number,
-  label: React.PropTypes.node,
-  /**
-   * Input field type, e.g. select, checkbox, radio, text, tel, email
-   * @default 'text'
-   */
-  type: React.PropTypes.string,
-  defaultValue: React.PropTypes.string,
-  placeholder: React.PropTypes.string,
-  id: React.PropTypes.string,
-  name: React.PropTypes.string,
-  validate: React.PropTypes.bool,
-  browserDefault: React.PropTypes.bool,
-  onChange: React.PropTypes.func
+    s: React.PropTypes.number,
+    m: React.PropTypes.number,
+    l: React.PropTypes.number,
+    label: React.PropTypes.node,
+    /**
+    * Input field type, e.g. select, checkbox, radio, text, tel, email
+    * @default 'text'
+    */
+    type: React.PropTypes.string,
+    defaultValue: React.PropTypes.string,
+    placeholder: React.PropTypes.string,
+    id: React.PropTypes.string,
+    name: React.PropTypes.string,
+    validate: React.PropTypes.bool,
+    browserDefault: React.PropTypes.bool,
+    onChange: React.PropTypes.func
 };
 
 Input.defaultProps = {type: 'text'};

--- a/src/Input.js
+++ b/src/Input.js
@@ -9,6 +9,7 @@ class Input extends React.Component {
     this.state = {value: this.props.defaultValue};
     this._onChange = this._onChange.bind(this);
     this.isSelect = this.isSelect.bind(this);
+    this.focus = this.focus.bind(this);
   }
 
   componentDidMount() {
@@ -46,6 +47,10 @@ class Input extends React.Component {
     if (this.props.onChange) {
       this.props.onChange(e);
     }
+  }
+
+  focus() {
+  	this.input.focus();
   }
 
   render() {
@@ -146,6 +151,7 @@ class Input extends React.Component {
                 onChange={this._onChange}
                 placeholder={placeholder}
                 type={inputType}
+                ref={ref => {this.input = ref;}}
                 {...props}
             />
             {htmlLabel}


### PR DESCRIPTION
I added ref and focus method to the Input component so that I can programatically focus the input.

By doing this, I can 

```javascript
<Input name="username" label="username" ref={ ref => { this.usernameInput } }/>
/* codes... */
this.usernameInput.focus();
```
Is there any better way to do this without modfying the Component? 

Thanks!