### PR TITLE
adding ref and focus method to the Input component

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -9,6 +9,7 @@ class Input extends React.Component {
     this.state = {value: this.props.defaultValue};
     this._onChange = this._onChange.bind(this);
     this.isSelect = this.isSelect.bind(this);
+    this.focus = this.focus.bind(this);
   }
 
   componentDidMount() {
@@ -46,6 +47,10 @@ class Input extends React.Component {
     if (this.props.onChange) {
       this.props.onChange(e);
     }
+  }
+
+  focus() {
+    this.input.focus();
   }
 
   render() {
@@ -146,6 +151,7 @@ class Input extends React.Component {
                 onChange={this._onChange}
                 placeholder={placeholder}
                 type={inputType}
+                ref={ (ref) => {this.input = ref; } }
                 {...props}
             />
             {htmlLabel}


### PR DESCRIPTION
I added ref and focus method to the Input component so that I can programatically focus the input.

By doing this, I can 

``` javascript
<Input name="username" label="username" ref={ ref => { this.usernameInput } }/>
/* codes... */
this.usernameInput.focus();
```

Is there any better way to do this without modfying the Component file? 

Thanks!
