### PR TITLE
Cleanup props before rendering HTML element proposal

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import constants from './constants';
+import cleanProps from './clean-props';
 import cx from 'classnames';
 import Icon from './Icon';
 import idgen from './idgen';
@@ -37,6 +38,7 @@ class Button extends React.Component {
     if (fab) {
       return this.renderFab(cx(classes, className));
     } else {
+      props = cleanProps(props);
       return (
         <C {...props} className={cx(classes, className)}>
           { this.renderIcon() }

--- a/src/clean-props.js
+++ b/src/clean-props.js
@@ -1,0 +1,18 @@
+
+export default function cleanProps(props) {
+  for (let i = 0, len = PROPS_FILTER.length; i < len; ++i) {
+    let prop = PROPS_FILTER[i];
+    if (prop in props) {
+      delete props[prop];
+    }
+  }
+  return props;
+}
+
+
+const PROPS_FILTER = [
+  'flat',
+  'floating',
+  'large',
+  'node',
+];


### PR DESCRIPTION
This is a solution to solve issue #87. This actually solves the three PhantomJS errors (or warnings) from the current test cases. Adding more props to filter, and integrating it to the affected components should solve the problem and render cleaner HTML.