### PR TITLE
issue#74: Changes the reference to provide a valid DOM element

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -35,7 +35,7 @@ class Dropdown extends Component {
     const { trigger } = this.props;
 
     return React.cloneElement( trigger, {
-      ref: (t) => this._trigger = t,
+      ref: (t) => this._trigger = `[data-activates=${this.idx}]`,
       className: 'dropdown-button',
       'data-activates': this.idx
     });


### PR DESCRIPTION
Uses the this.idx prop as a jQuery selector to find the DOM element on componentDidMount after the init call
