### PR TITLE
Adding configurable on/off labels

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -124,14 +124,14 @@ class Input extends Component {
       return (
         <div className='switch'>
           <label>
-            {offLabel || "Off"}
+            {offLabel || 'Off'}
             <input
               {...other}
               onChange={this._onChange}
               type='checkbox'
             />
             <span className='lever' />
-            {onLabel || "On"}
+            {onLabel || 'On'}
           </label>
         </div>
       );
@@ -188,6 +188,8 @@ Input.propTypes = {
   name: PropTypes.string,
   validate: PropTypes.bool,
   browserDefault: PropTypes.bool,
+  onLabel: PropTypes.string,
+  offLabel: PropTypes.string,
   onChange: PropTypes.func
 };
 

--- a/src/Input.js
+++ b/src/Input.js
@@ -64,6 +64,8 @@ class Input extends Component {
       l,
       type,
       validate,
+      onLabel,
+      offLabel,
       ...other
     } = this.props;
     let sizes = { s, m, l };
@@ -122,14 +124,14 @@ class Input extends Component {
       return (
         <div className='switch'>
           <label>
-            Off
+            {offLabel || "Off"}
             <input
               {...other}
               onChange={this._onChange}
               type='checkbox'
             />
             <span className='lever' />
-            On
+            {onLabel || "On"}
           </label>
         </div>
       );

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -52,4 +52,13 @@ describe('Input', function() {
     assert.equal(options[0].getAttribute('disabled'), '');
     assert.equal(options[0].value, defaultOption);
   });
+
+  it('renders a switch with custom labels',  function() {
+    let instance = TestUtils.renderIntoDocument(
+        <Input type='switch'/>
+      );
+
+    let input = TestUtils.findRenderedDOMComponentWithTag(instance, 'div');
+    assert.include(input.className, 'checkbox');
+  });
 });

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -58,7 +58,7 @@ describe('Input', function() {
         <Input type='switch'/>
       );
 
-    let input = TestUtils.findRenderedDOMComponentWithTag(instance, 'div');
-    assert.include(input.className, 'checkbox');
+    let input = TestUtils.findRenderedDOMComponentWithTag(instance, 'input');
+    assert.include(ReactDOM.findDOMNode(input).type, 'checkbox');
   });
 });


### PR DESCRIPTION
This is an enhancement to configure the fixed "on/off" labels for the switch button, in order to place a label in another language for non-english users and also if is required to set another message than "on/off" (i.e. enable/disable, active/inactive) and letting the "on/off" as default if it's not provided.