### PR TITLE
remove unknown props of <ul>

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -18,7 +18,7 @@ class Dropdown extends Component {
   }
 
   render () {
-    const { children, ...props } = this.props;
+    const { children, trigger, ...props } = this.props;
     this.idx = 'dropdown_' + idgen();
 
     return (


### PR DESCRIPTION
Hi!

thanks for this useful library.
I'm new user of react-materialize.

when I use Dropdown.js, I came across this waring. (at react v15.3.1)

```
warning.js:36 Warning: Unknown prop `trigger` on <ul> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in ul (created by Dropdown)
    in span (created by Dropdown)
    in Dropdown (created by Header)
    in li (created by Header)
    in ul (created by Header)
    in div (created by Header)
    in nav (created by Header)
    in div (created by Header)
    in Header (created by Connect(Header))
    in Connect(Header) (created by Root)
    in div (created by Root)
    in Root (created by RouterContext)
    in RouterContext (created by Router)
    in Router
    in Provider
```

so, I open this PR. please check it.