### PR TITLE
Fixed missing props and invalid Collapsible states 

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import cx from 'classnames';
 
-class Collapsible extends React.Component {
+class Collapsible extends Component {
   constructor (props) {
     super(props);
     this.renderItem = this.renderItem.bind(this);
@@ -12,7 +12,16 @@ class Collapsible extends React.Component {
   }
 
   render () {
-    const { accordion, popout, className, children, ...props } = this.props;
+    const {
+      accordion,
+      popout,
+      className,
+      children,
+      ...props
+    } = this.props;
+
+    delete props.defaultActiveKey;
+
     const classes = {
       collapsible: true,
       popout
@@ -59,15 +68,19 @@ Collapsible.propTypes = {
    * or it can only allow one section to stay open at a time, which is called an accordion.
    * @default false
    */
-  accordion: React.PropTypes.bool,
-  className: React.PropTypes.string,
-  children: React.PropTypes.node,
+  accordion: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.node,
   /**
    * Enable popout style
    */
-  popout: React.PropTypes.bool,
-  defaultActiveKey: React.PropTypes.number,
-  onSelect: React.PropTypes.func
+  popout: PropTypes.bool,
+  /**
+   * The default CollapsibleItem that should be expanded. This value should match the specified
+   * item's eventKey value. Ignored if accordion is false.
+   */
+  defaultActiveKey: PropTypes.any,
+  onSelect: PropTypes.func
 };
 
 Collapsible.defaultProps = {

--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -19,7 +19,7 @@ class CollapsibleItem extends Component {
       node,
       header,
       icon,
-      classes,
+      className,
       ...props
     } = this.props;
 
@@ -36,7 +36,7 @@ class CollapsibleItem extends Component {
     };
 
     return (
-      <li className={cx(liClasses, classes)} {...props}>
+      <li className={cx(liClasses, className)} {...props}>
         <C className={cx(headerClasses)} onClick={this.handleClick}>
           {icon ? this.renderIcon(icon) : null}
           {header}
@@ -84,6 +84,7 @@ CollapsibleItem.propTypes = {
    * The value to pass to the onSelect callback.
    */
   eventKey: PropTypes.any,
+  className: PropTypes.string,
   /**
    * The node type of the header
    * @default a

--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -19,19 +19,25 @@ class CollapsibleItem extends Component {
       node,
       header,
       icon,
+      classes,
       ...props
     } = this.props;
 
     delete props.expanded;
+    delete props.eventKey;
 
     const C = node;
-    const classes = {
-      'collapsible-header': true
+    const liClasses = {
+      active: this.state.expanded
+    };
+    const headerClasses = {
+      'collapsible-header': true,
+      active: this.state.expanded
     };
 
     return (
-      <li {...props}>
-        <C className={cx(classes)} onClick={this.handleClick}>
+      <li className={cx(liClasses, classes)} {...props}>
+        <C className={cx(headerClasses)} onClick={this.handleClick}>
           {icon ? this.renderIcon(icon) : null}
           {header}
         </C>
@@ -51,9 +57,8 @@ class CollapsibleItem extends Component {
   }
 
   renderBody () {
-    if (!this.state.expanded) return;
+    const style = this.state.expanded ? { display: 'block' } : {};
 
-    const style = {display: 'block'};
     return (
       <div className='collapsible-body' style={style}>
         {this.props.children}
@@ -67,17 +72,16 @@ class CollapsibleItem extends Component {
 }
 
 CollapsibleItem.propTypes = {
-  children: PropTypes.node,
   header: PropTypes.string.isRequired,
   icon: PropTypes.string,
   onSelect: PropTypes.func,
   /**
-   * If the item is expanded by default
+   * If the item is expanded by default. Overridden if the parent Collapsible is an accordion.
    * @default false
    */
   expanded: PropTypes.bool,
   /**
-   * The value to pass to the onSelect callback
+   * The value to pass to the onSelect callback.
    */
   eventKey: PropTypes.any,
   /**


### PR DESCRIPTION
This pull request makes `Collapsible` and `CollapsibleItem` consistent with Materialize.js' specifications and markup. It also fixes invalid props issues and wrong CSS styles under certain conditions. Some propTypes' comments were also edited for added precision.