### PR TITLE
Fixes Modal not working after Materialize update

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -27,7 +27,7 @@ class OverlayTrigger extends Overlay {
   }
 
   showOverlay () {
-    $(`#${this.overlayID}`).openModal(this.props.modalOptions);
+    $(`#${this.overlayID}`).modal(this.props.modalOptions).modal('open');
   }
 }
 


### PR DESCRIPTION
Materializecss updated their Modal with breaking changes.
Before:
`$(elem).openModal();`
Now:
`$(elem).modal(modalOptions).modal('open');`