### PR TITLE
Fixed bug with dynamic children in Collapsible

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -30,12 +30,14 @@ class Collapsible extends Component {
 
     return (
       <ul className={cx(className, classes)} {...props} data-collapsible={collapsible}>
-        {React.Children.map(children.filter(x => !!x), this.renderItem)}
+        {React.Children.map(children, this.renderItem)}
       </ul>
     );
   }
 
   renderItem (child) {
+    if (!child) return null;
+
     const props = {};
 
     if (this.props.accordion) {

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -30,16 +30,14 @@ class Collapsible extends Component {
 
     return (
       <ul className={cx(className, classes)} {...props} data-collapsible={collapsible}>
-        {React.Children.map(children, this.renderItem)}
+        {React.Children.map(children.filter(x => !!x), this.renderItem)}
       </ul>
     );
   }
 
-  renderItem (child, index) {
-    const props = {
-      key: child.key ? child.key : index,
-      ref: child.ref
-    };
+  renderItem (child) {
+    const props = {};
+
     if (this.props.accordion) {
       props.expanded = child.props.eventKey === this.state.activeKey;
       props.onSelect = this.handleSelect;

--- a/test/CollapsibleSpec.js
+++ b/test/CollapsibleSpec.js
@@ -31,6 +31,35 @@ describe('<Collapsible />', () => {
     assert(wrapper.find('[data-collapsible="accordion"]').length, 'with a data attribute');
   });
 
+  it('should work with null dynamic children', () => {
+    let wrapper = mount(
+      <Collapsible accordion>
+        {null}
+        <CollapsibleItem header='First'>
+          Lorem ipsum dolor sit amet.
+        </CollapsibleItem>
+      </Collapsible>
+    );
+
+    assert(wrapper.find('[data-collapsible="accordion"]').length);
+  });
+
+  it('should pass the key props to its children', () => {
+    let wrapper = mount(
+      <Collapsible accordion>
+        <CollapsibleItem header='First' key="testKey">
+          Lorem ipsum dolor sit amet.
+        </CollapsibleItem>
+        <CollapsibleItem header='First' key="testKey">
+          Lorem ipsum dolor sit amet.
+        </CollapsibleItem>
+      </Collapsible>
+    );
+
+    // Should only render one of the two children
+    assert.strictEqual(wrapper.find('li').length, 1);
+  });
+
   describe('<CollapsibleItem />', () => {
     it('renders', () => {
       let wrapper = mount(

--- a/test/CollapsibleSpec.js
+++ b/test/CollapsibleSpec.js
@@ -45,19 +45,17 @@ describe('<Collapsible />', () => {
   });
 
   it('should pass the key props to its children', () => {
-    let wrapper = mount(
+    let collapsibleChildren = mount(
       <Collapsible accordion>
-        <CollapsibleItem header='First' key="testKey">
+        <li key='testKey'>
           Lorem ipsum dolor sit amet.
-        </CollapsibleItem>
-        <CollapsibleItem header='First' key="testKey">
-          Lorem ipsum dolor sit amet.
-        </CollapsibleItem>
+        </li>
       </Collapsible>
-    );
+    ).find('li');
 
-    // Should only render one of the two children
-    assert.strictEqual(wrapper.find('li').length, 1);
+    // .key() returns `.$testKey`. Don't make future assumptions about
+    // how React implements keys -> test that the substring testKey is in there
+    assert(collapsibleChildren.at(0).key().indexOf('testKey') >= 0);
   });
 
   describe('<CollapsibleItem />', () => {

--- a/test/CollapsibleSpec.js
+++ b/test/CollapsibleSpec.js
@@ -41,7 +41,7 @@ describe('<Collapsible />', () => {
       </Collapsible>
     );
 
-    assert(wrapper.find('[data-collapsible="accordion"]').length);
+    assert.strictEqual(wrapper.find('li').length, 1);
   });
 
   it('should pass the key props to its children', () => {


### PR DESCRIPTION
A React component's children can sometimes be `null`, e.g. when adding children dynamically based on a condition. Added a filter before rendering them in Collapsible.

Example use case that triggered the bug:
```js
let item2 = null;
if (condition) {
    item2 = <BaseItem eventKey="item2"  />;
}

<Collapsible accordion>
    <BaseItem eventKey="item1" />
    {item2}
</Collapsible>
```

Also, cleared the `key` and `ref` passed to `React.cloneElement`, because [according to the docs](https://facebook.github.io/react/docs/react-api.html#createelement), `key` and `ref` will be preserved anyway.