### PR TITLE
Collapsible Item: Allow icon class prop

### DIFF
--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -19,6 +19,7 @@ class CollapsibleItem extends Component {
       node,
       header,
       icon,
+      iconClassName,
       className,
       ...props
     } = this.props;
@@ -38,7 +39,7 @@ class CollapsibleItem extends Component {
     return (
       <li className={cx(liClasses, className)} {...props}>
         <C className={cx(headerClasses)} onClick={this.handleClick}>
-          {icon ? this.renderIcon(icon) : null}
+          {icon ? this.renderIcon(icon, iconClassName) : null}
           {header}
         </C>
         { this.renderBody() }
@@ -66,14 +67,16 @@ class CollapsibleItem extends Component {
     );
   }
 
-  renderIcon (icon) {
-    return <Icon>{icon}</Icon>;
+  renderIcon (icon, iconClassName) {
+    return <Icon className={iconClassName}>{icon}</Icon>;
   }
 }
 
 CollapsibleItem.propTypes = {
   header: PropTypes.string.isRequired,
   icon: PropTypes.string,
+  iconClassName: PropTypes.string,
+  children: PropTypes.node,
   onSelect: PropTypes.func,
   /**
    * If the item is expanded by default. Overridden if the parent Collapsible is an accordion.

--- a/test/CollapsibleSpec.js
+++ b/test/CollapsibleSpec.js
@@ -53,7 +53,7 @@ describe('<Collapsible />', () => {
     it('accepts icon props', () => {
       let wrapper = mount(
         <Collapsible accordion>
-          <CollapsibleItem header='First' icon='filter_drama' iconClassName="right">
+          <CollapsibleItem header='First' icon='filter_drama' iconClassName='right'>
             Lorem ipsum dolor sit amet.
           </CollapsibleItem>
         </Collapsible>

--- a/test/CollapsibleSpec.js
+++ b/test/CollapsibleSpec.js
@@ -53,13 +53,12 @@ describe('<Collapsible />', () => {
     it('accepts icon props', () => {
       let wrapper = mount(
         <Collapsible accordion>
-          <CollapsibleItem header='First' icon='filter_drama'>
+          <CollapsibleItem header='First' icon='filter_drama' iconClassName="right">
             Lorem ipsum dolor sit amet.
           </CollapsibleItem>
         </Collapsible>
       );
-
-      assert(wrapper.contains(<i className='material-icons'>filter_drama</i>), 'with rendered icon');
+      assert(wrapper.contains(<i className='material-icons right'>filter_drama</i>), 'with rendered icon');
     });
   });
 });


### PR DESCRIPTION
As mentioned in #159 , this allows to pass a custom className to the icon being rendered in the header.