### PR TITLE
if the dropdown trigger has a className it will now be preserved.

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -41,9 +41,11 @@ class Dropdown extends Component {
   renderTrigger () {
     const { trigger } = this.props;
 
+    const className = typeof trigger.className === 'string' ? `${trigger.className} dropdown-button` : 'dropdown-button';
+
     return React.cloneElement(trigger, {
       ref: (t) => (this._trigger = `[data-activates=${this.idx}]`),
-      className: 'dropdown-button',
+      className,
       'data-activates': this.idx
     });
   }


### PR DESCRIPTION
Hi, I was using this dropdown and found that the trigger would get its class list stripped. I made a small fix to make sure it keeps it if it exists.