### PR TITLE
Change jsdom setup in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-react": "^6.2.0",
     "eslint-plugin-standard": "^2.0.0",
     "jsdom": "^9.9.1",
+    "jsdom-global": "^2.1.1",
     "materialize-css": "^0.98.0",
     "mocha": "^3.2.0",
     "react-addons-test-utils": "^15.4.2",

--- a/test/helpers/helper.js
+++ b/test/helpers/helper.js
@@ -1,32 +1,9 @@
-const exposedProperties = ['window', 'navigator', 'document'];
+require('jsdom-global')();
 
-const expect = require('chai').expect;
-const jsdom = require('jsdom').jsdom;
+global.expect = require('chai').expect;
 global.sinon = require('sinon');
-global.jsdom = jsdom.jsdom;
-global.React = require('react');
-global.ReactDOM = require('react-dom');
-global.TestUtils = require('react-addons-test-utils');
-global.expect = expect;
-
-global.document = jsdom('');
-global.window = document.defaultView;
 
 global.$ = require('jquery');
 
-// TODO not sure about this
 global.$.fn.material_select = () => this;
 global.$.fn.sideNav = () => this;
-
-Object.keys(document.defaultView).forEach(
-  (property) => {
-    if (typeof global[property] === 'undefined') {
-      exposedProperties.push(property);
-      global[property] = document.defaultView[property];
-    }
-  }
-);
-
-global.navigator = {
-  userAgent: 'Node.js'
-};


### PR DESCRIPTION
Add [jsdom-global](https://github.com/rstacruz/jsdom-global) to reduce the boilerplate to setup jsdom in our tests. Also, it will remove some unnecessary global variables.

Reference: https://github.com/react-materialize/react-materialize/pull/213