### PR TITLE
Fix PropTypes warning and linting issues

### DIFF
--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -2,25 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Col from './Col';
 
-const Breadcrumb = ({ children }) => (
+const Breadcrumb = ({ cols, children }) => (
   <nav className='row'>
     <div className='nav-wrapper'>
-      <Col s={12}>
-        { renderChildren(children) }
+      <Col s={cols}>
+        { React.Children.map(children, item => React.cloneElement(item, { className: 'breadcrumb' })) }
       </Col>
     </div>
   </nav>
 );
 
-const renderChildren = (children) => {
-  return React.Children.map(children, (item) => {
-    return React.cloneElement(item, { className: 'breadcrumb' });
-  });
-};
-
 Breadcrumb.propTypes = {
   children: PropTypes.node,
   cols: PropTypes.number
+};
+
+Breadcrumb.defaultProps = {
+  cols: 12
 };
 
 export default Breadcrumb;

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -1,34 +1,36 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import constants from './constants';
 import cx from 'classnames';
 
-class Icon extends Component {
-  render () {
-    let classes = {
-      'material-icons': true
-    };
-    constants.PLACEMENTS.forEach(p => {
-      classes[p] = this.props[p];
-    });
+const Icon = (props) => {
+  let classes = {
+    'material-icons': true
+  };
+  constants.PLACEMENTS.forEach(p => {
+    classes[p] = props[p];
+  });
 
-    constants.ICON_SIZES.forEach(s => {
-      classes[s] = this.props[s];
-    });
+  constants.ICON_SIZES.forEach(s => {
+    classes[s] = props[s];
+  });
 
-    return (
-      <i className={cx(classes, this.props.className)}>{this.props.children}</i>
-    );
-  }
-}
+  return (
+    <i className={cx(classes, props.className)}>{props.children}</i>
+  );
+};
 
 Icon.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
-  tiny: PropTypes.bool,
-  small: PropTypes.bool,
-  medium: PropTypes.bool,
-  large: PropTypes.bool
+  children: PropTypes.node
 };
+
+constants.PLACEMENTS.forEach(p => {
+  Icon.propTypes[p] = PropTypes.bool;
+});
+
+constants.ICON_SIZES.forEach(s => {
+  Icon.propTypes[s] = PropTypes.bool;
+});
 
 export default Icon;

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from './Icon';
 import PaginationButton from './PaginationButton';


### PR DESCRIPTION
When importing the module React throws the following warning...

```
warning.js:36 Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```

This PR fixes that warning, and also a few linting issues.