### PR TITLE
added check for this.props.value while setting active state on Input

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -10,7 +10,7 @@ class Input extends Component {
     super(props);
 
     this.state = {
-      value: props.defaultValue
+      value: props.value || props.defaultValue
     };
 
     this._onChange = this._onChange.bind(this);
@@ -116,7 +116,7 @@ class Input extends Component {
         inputType = type || 'text';
     }
     let labelClasses = {
-      active: this.state.value || this.isSelect() || this.props.value
+      active: this.state.value || this.isSelect()
     };
 
     let htmlLabel = label || inputType === 'radio'

--- a/src/Input.js
+++ b/src/Input.js
@@ -116,7 +116,7 @@ class Input extends Component {
         inputType = type || 'text';
     }
     let labelClasses = {
-      active: this.state.value || this.isSelect()
+      active: this.state.value || this.isSelect() || this.props.value
     };
 
     let htmlLabel = label || inputType === 'radio'


### PR DESCRIPTION
I had a problem where on I was binding `Input` (type=text) to a value in a model:
```
<Input type="text" label="Value:" value={this.state.onsiteRenewableEnergyProductionTxt.toString()} />
```

on the initial load of the component, it would display with the `active` label class:
<img width="123" alt="screen shot 2017-05-21 at 3 03 36 pm" src="https://cloud.githubusercontent.com/assets/433221/26284230/c6c02974-3e36-11e7-9f60-2f7ed2ec9d5d.png">

but on subsequent renderings it would not have the `active` class.

<img width="118" alt="screen shot 2017-05-21 at 3 02 23 pm" src="https://cloud.githubusercontent.com/assets/433221/26284226/932b4846-3e36-11e7-913f-b5e925366ea6.png">

This is a small fix (maybe not the right place) which will check `this.props.value` and add the `active` class to label if it exists.

Let me know what yall think.  I would love to get this merged.  Thanks for the great project. 