### PR TITLE
Icon component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,3 +15,4 @@ env:
 rules:
   react/jsx-no-bind: [0]
   semi: [2, 'always']
+  react/no-unused-prop-types: [0]

--- a/docs/src/pages/IconsPage.js
+++ b/docs/src/pages/IconsPage.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import Row from 'Row';
+import Col from 'Col';
+import ReactPlayground from './ReactPlayground';
+import PropTable from './PropTable';
+import Samples from './Samples';
+import iconSimple from '../../../examples/IconSimple';
+import iconSizes from '../../../examples/IconSizes';
+import Code from '!raw-loader!Icon';
+
+const IconsPage = () => (
+  <Row>
+    <Col m={9} s={12} l={10}>
+      <p className='caption'>
+        We have included 740 Material Design Icons courtesy of Google. You can download them directly from the
+        {' '}
+        <a href='http://google.github.io/material-design-icons/#icon-font-for-the-web' target='_blank'>
+          Material Design specs
+        </a>.
+      </p>
+      <h4 className='col s12'>
+        Simple
+      </h4>
+      <Col s={12}>
+        <ReactPlayground code={Samples.iconSimple}>
+          {iconSimple}
+        </ReactPlayground>
+      </Col>
+      <h4 className='col s12'>
+        Sizes
+      </h4>
+      <Col s={12}>
+        <ReactPlayground code={Samples.iconSizes}>
+          {iconSizes}
+        </ReactPlayground>
+      </Col>
+      <h4 className='col s12'>
+        Position
+      </h4>
+      <Col s={12}>
+        <a href='#/buttons'>Check out example in Buttons</a>
+      </Col>
+      <Col s={12}>
+        <PropTable header='Icon' component={Code} />
+      </Col>
+    </Col>
+  </Row>
+);
+
+export default IconsPage;

--- a/docs/src/pages/Samples.js
+++ b/docs/src/pages/Samples.js
@@ -21,6 +21,8 @@ export default {
   footer: require('!raw-loader!../../../examples/Footer.js'),
   grid: require('!raw-loader!../../../examples/Grid.js'),
   horizontalFab: require('!raw-loader!../../../examples/HorizontalFAB.js'),
+  iconSimple: require('!raw-loader!../../../examples/IconSimple.js'),
+  iconSizes: require('!raw-loader!../../../examples/IconSizes.js'),
   iconLinksNavbar: require('!raw-loader!../../../examples/IconLinksNavbar.js'),
   iconPrefixesInput: require('!raw-loader!../../../examples/IconPrefixesInput.js'),
   inputCheckbox: require('!raw-loader!../../../examples/InputCheckbox.js'),

--- a/docs/src/routes.js
+++ b/docs/src/routes.js
@@ -20,6 +20,7 @@ import ChipsPage from './pages/ChipsPage';
 import CollectionsPage from './pages/CollectionsPage';
 import FooterPage from './pages/FooterPage';
 import FormsPage from './pages/FormsPage';
+import IconsPage from './pages/IconsPage';
 import NavbarPage from './pages/NavbarPage';
 import PaginationPage from './pages/PaginationPage';
 import PreloaderPage from './pages/PreloaderPage';
@@ -47,6 +48,7 @@ const components = {
   collections: CollectionsPage,
   footer: FooterPage,
   forms: FormsPage,
+  icon: IconsPage,
   navbar: NavbarPage,
   pagination: PaginationPage,
   preloader: PreloaderPage

--- a/examples/IconSimple.js
+++ b/examples/IconSimple.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import Icon from '../src/Icon';
+
+export default
+<Icon>insert_chart</Icon>;

--- a/examples/IconSizes.js
+++ b/examples/IconSizes.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Section from '../src/Section';
+import Icon from '../src/Icon';
+import Row from '../src/Row';
+import Col from '../src/Col';
+
+export default
+<Section>
+  <Row className='center'>
+    <Col s={3}>
+      <Icon tiny>insert_chart</Icon>
+      <p>tiny</p>
+    </Col>
+    <Col s={3}>
+      <Icon small>insert_chart</Icon>
+      <p>small</p>
+    </Col>
+    <Col s={3}>
+      <Icon medium>insert_chart</Icon>
+      <p>medium</p>
+    </Col>
+    <Col s={3}>
+      <Icon large>insert_chart</Icon>
+      <p>large</p>
+    </Col>
+  </Row>
+</Section>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "files": [

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -21,16 +21,27 @@ const Icon = (props) => {
 };
 
 Icon.propTypes = {
+  /*
+   * Classname passed to i tag
+   */
   className: PropTypes.string,
-  children: PropTypes.node
+  /*
+   * Icon type: <a href='https://material.io/icons/'>https://material.io/icons/</a>
+   */
+  children: PropTypes.string,
+  /*
+   * Placement for icon if used beside a text ↓
+   */
+  left: PropTypes.node,
+  center: PropTypes.node,
+  right: PropTypes.node,
+  /*
+   * Sizes for icons ↓
+   */
+  tiny: PropTypes.node,
+  small: PropTypes.node,
+  medium: PropTypes.node,
+  large: PropTypes.node
 };
-
-constants.PLACEMENTS.forEach(p => {
-  Icon.propTypes[p] = PropTypes.bool;
-});
-
-constants.ICON_SIZES.forEach(s => {
-  Icon.propTypes[s] = PropTypes.bool;
-});
 
 export default Icon;

--- a/src/Input.js
+++ b/src/Input.js
@@ -235,7 +235,11 @@ Input.propTypes = {
   browserDefault: PropTypes.bool,
   onLabel: PropTypes.string,
   offLabel: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  /**
+   * Value used to set a initial value
+   */
+  value: PropTypes.string
 };
 
 Input.defaultProps = { type: 'text' };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --inline-diffs
---reporter min
 --require test/helper/noop.compiler.js
 --compilers js:babel-register
 test/helper.js


### PR DESCRIPTION
Fixes #264 
Creates an Icon page in the docs.

plus
 - removes unused prop from eslint
 - removes min reporter from mocha
 - adds more info about Icon props to src/Icon