### PR TITLE
Fixes active input label overlapping number values

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -62,6 +62,7 @@ class Input extends Component {
     var types = {
       'checkbox': e.target.checked,
       'select-multiple': this.getMultipleValues(e.target),
+      'number': parseFloat(e.target.value),
       'default': e.target.value
     };
     const value = types[e.target.type] || types['default'];
@@ -120,7 +121,8 @@ class Input extends Component {
         inputType = type || 'text';
     }
     let labelClasses = {
-      active: this.state.value || this.isSelect()
+      active: this.state.value || this.isSelect() || this.props.value ||
+        this.state.value === 0 || this.props.value === 0
     };
 
     let htmlLabel = label || inputType === 'radio'
@@ -262,7 +264,10 @@ Input.propTypes = {
   /**
    * Value used to set a initial value
    */
-  value: PropTypes.string
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ])
 };
 
 Input.defaultProps = { type: 'text' };

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -93,4 +93,22 @@ describe('<Input />', () => {
     expect(spy).to.have.been.calledWith(options);
     spy.restore();
   });
+
+  it('renders a number picker without an active label', () => {
+    const label = 'I have a label';
+    wrapper = shallow(
+      <Input type='number' label={label} />
+    );
+    expect(wrapper.find('label').hasClass('active')).to.equal(false);
+  });
+
+  it('renders a number picker with an active label', () => {
+    const label = 'I have a label';
+    const value = 0;
+    wrapper = mount(
+      <Input type='number' label={label} value={value} />
+    );
+    expect(wrapper.props().value).to.equal(value);
+    expect(wrapper.find('label').hasClass('active')).to.equal(true);
+  });
 });


### PR DESCRIPTION
There was a bug when the input had value from the props and no state yet because it has not been changed by the user. The label would overlap the value inside the input

### Before : 
![before](https://cloud.githubusercontent.com/assets/6985756/26778493/c87c473c-49e1-11e7-975f-3991b9054711.gif)
### After :
![after](https://cloud.githubusercontent.com/assets/6985756/26778495/cb853c72-49e1-11e7-9b37-047ad399a398.gif)
