### PR TITLE
Passes custom props in Row to Node

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-const Row = ({ children, className, node: Node = 'div' }) =>
-  <Node className={cx('row', className)}>{ children }</Node>;
+const Row = ({ children, className, node: Node = 'div', ...props }) =>
+  <Node className={cx('row', className)} {...props}>{ children }</Node>;
 
 Row.propTypes = {
   children: PropTypes.node,

--- a/test/RowSpec.js
+++ b/test/RowSpec.js
@@ -1,16 +1,26 @@
-/* global describe, it */
+/* global describe, it, expect */
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { assert } from 'chai';
 import Row from '../src/Row';
 
-let wrapper = shallow(
-  <Row />
-);
+let wrapper;
 
 describe('<Row />', () => {
-  it('should render', () => {
-    assert(wrapper.find('.row').length, 'a row');
+  it('renders', () => {
+    wrapper = shallow(<Row />);
+    expect(wrapper.hasClass('row')).to.be.truthy;
+  });
+
+  it('accepts a node prop', () => {
+    const node = 'a';
+    wrapper = shallow(<Row node={node} />);
+    expect(wrapper.type()).to.eq(node);
+  });
+
+  it('passes other props to node', () => {
+    const style = { color: 'red' };
+    wrapper = shallow(<Row style={style} />);
+    expect(wrapper.prop('style')).to.be.equal(style);
   });
 });


### PR DESCRIPTION
- Passes custom props to Node
- Improves `Row` specs

Fixes #282 