### PR TITLE
Fix issue with `striped` prop in Table Component

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -11,7 +11,7 @@ class Table extends Component {
       className,
       hoverable,
       responsive,
-      stripped,
+      striped,
       ...props
     } = this.props;
 
@@ -19,7 +19,7 @@ class Table extends Component {
       centered: centered,
       highlight: hoverable,
       'responsive-table': responsive,
-      stripped: stripped,
+      striped: striped,
       bordered: bordered
     };
 
@@ -50,10 +50,10 @@ Table.propTypes = {
   */
   responsive: PropTypes.bool,
   /**
-  * Stripped style
+  * striped style
   * @default false
   */
-  stripped: PropTypes.bool,
+  striped: PropTypes.bool,
   /**
   * Add border to each row
   * @default false

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -11,7 +11,7 @@ const wrapper = shallow(
     centered
     hoverable
     responsive
-    stripped
+    striped
   >
     <tr>
       <td>foo</td>
@@ -23,7 +23,7 @@ const wrapper = shallow(
 describe('<Table />', () => {
   it('has various mod props', () => {
     assert(wrapper.find('.centered').length, 'adds a centered className');
-    assert(wrapper.find('.stripped').length, 'adds a stripped className');
+    assert(wrapper.find('.striped').length, 'adds a striped className');
     assert(wrapper.find('.responsive-table').length, 'adds a responsive-table className');
     assert(wrapper.find('.bordered').length, 'adds a bordered className');
     assert(wrapper.find('.highlight').length, 'adds a highlight className');


### PR DESCRIPTION
This PR fixes the typographical error issue in the `striped` prop inside the Table component, the prop is written as `stripped` instead of `striped` hence it adds a `stripped` class to the table element instead of the correct `striped` class. This PR fixes this issue