### PR TITLE
Turn button into link if href is present

### DIFF
--- a/docs/src/pages/ButtonsPage.js
+++ b/docs/src/pages/ButtonsPage.js
@@ -10,6 +10,7 @@ import raisedButton from '../../../examples/RaisedButton';
 import fixedActionButton from '../../../examples/FixedActionButton';
 import floatingButton from '../../../examples/FloatingButton';
 import horizontalFab from '../../../examples/HorizontalFAB';
+import buttonAsLink from '../../../examples/ButtonAsLink';
 
 const ButtonsPage = () => (
   <Row>
@@ -49,7 +50,14 @@ const ButtonsPage = () => (
           {horizontalFab}
         </ReactPlayground>
       </Col>
-
+      <h4 className='col s12'>
+        Button as Link
+      </h4>
+      <Col s={12}>
+        <ReactPlayground code={Samples.buttonAsLink}>
+          {buttonAsLink}
+        </ReactPlayground>
+      </Col>
       <Col s={12}>
         <PropTable header='Buttons' component={ButtonCode} />
       </Col>

--- a/docs/src/pages/Samples.js
+++ b/docs/src/pages/Samples.js
@@ -21,6 +21,7 @@ export default {
   fixedActionButton: require('!raw-loader!../../../examples/FixedActionButton.js'),
   flatButton: require('!raw-loader!../../../examples/FlatButton.js'),
   floatingButton: require('!raw-loader!../../../examples/FloatingButton.js'),
+  buttonAsLink: require('!raw-loader!../../../examples/ButtonAsLink.js'),
   footer: require('!raw-loader!../../../examples/Footer.js'),
   grid: require('!raw-loader!../../../examples/Grid.js'),
   horizontalFab: require('!raw-loader!../../../examples/HorizontalFAB.js'),

--- a/examples/ButtonAsLink.js
+++ b/examples/ButtonAsLink.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Button from '../src/Button';
+import Icon from '../src/Icon';
+
+export default
+<div>
+    <Button waves='light' node='a' href='http://www.google.com'> Open Me In New Tab </Button>
+</div>;


### PR DESCRIPTION
I am using Buttons as links. This can already be accompished by writing
`<Button floating large className='red' waves='light' icon='add' node="a" href="../account/_add"/>`
This patch alllows to omit the node property.