### PR TITLE
Improve Collapsible Behaviour

### DIFF
--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -54,7 +54,7 @@ class CollapsibleItem extends Component {
           {icon && this.renderIcon(icon, iconClassName)}
           {header}
         </C>
-        {expanded && this.renderBody()}
+        {this.renderBody()}
       </li>
     );
   }
@@ -71,7 +71,7 @@ class CollapsibleItem extends Component {
 
   renderBody () {
     return (
-      <div className='collapsible-body' style={{ display: 'block' }}>
+      <div className='collapsible-body' style={{ display: 'none' }}>
         {this.props.children}
       </div>
     );
@@ -111,7 +111,7 @@ CollapsibleItem.propTypes = {
 
 CollapsibleItem.defaultProps = {
   expanded: false,
-  node: 'a'
+  node: 'div'
 };
 
 export default CollapsibleItem;

--- a/test/CollapsibleSpec.js
+++ b/test/CollapsibleSpec.js
@@ -74,7 +74,7 @@ describe('<Collapsible />', () => {
         </Collapsible>
       );
 
-      assert.strictEqual(wrapper.find('a.collapsible-header').length, 3);
+      assert.strictEqual(wrapper.find('div.collapsible-header').length, 3);
     });
 
     describe('each collapsible item', () => {


### PR DESCRIPTION
Improve behaviour for renderBody() and node type for Collapsible component

Currently the component for `Collapsible` is rendering like this: 

![37951c18-a1b1-11e6-886e-cca9618e1451](https://user-images.githubusercontent.com/5362629/29052469-5bd7091a-7bb8-11e7-97ce-ed0796ffac01.png)

However is should be rendering like this: 

![77a8299e-a1b1-11e6-913f-9da6698e5eec](https://user-images.githubusercontent.com/5362629/29052483-712e1560-7bb8-11e7-963d-c0f1a22a1e9b.png)

This PR changes the default node from `a` to `div` as it should be. Additionally, it ensures that the body is always rendered (`renderBody()`) just like the Materialize docs. 

Fixes #80 
