### PR TITLE
Fix parallax example and add documentation page (#331)

### DIFF
--- a/docs/src/pages/ParallaxPage.js
+++ b/docs/src/pages/ParallaxPage.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Row from 'Row';
+import Col from 'Col';
+import ReactPlayground from './ReactPlayground';
+import PropTable from './PropTable';
+import Samples from './Samples';
+import parallax from '../../../examples/Parallax';
+import parallaxCode from '!raw-loader!Parallax';
+
+const ParallaxPage = () => (
+  <Row>
+    <Col m={9} s={12} l={10}>
+      <p className='caption'>
+        Parallax is an effect where the background content or image in this 
+        case, is moved at a different speed than the foreground content while 
+        scrolling. Check out the demo to get a better idea of it.
+      </p>
+      <Col s={12}>
+        <ReactPlayground code={Samples.parallax}>
+          {parallax}
+        </ReactPlayground>
+      </Col>
+
+      <Col s={12}>
+        <PropTable component={parallaxCode} header='Parallax' />
+      </Col>
+    </Col>
+  </Row>
+);
+
+export default ParallaxPage;

--- a/docs/src/pages/Samples.js
+++ b/docs/src/pages/Samples.js
@@ -40,6 +40,7 @@ export default {
   modalWithBottomSheet: require('!raw-loader!../../../examples/ModalWithBottomSheet.js'),
   modalWithFixedFooter: require('!raw-loader!../../../examples/ModalWithFixedFooter.js'),
   pagination: require('!raw-loader!../../../examples/Pagination.js'),
+  parallax: require('!raw-loader!../../../examples/Parallax.js'),
   prefillingTextInput: require('!raw-loader!../../../examples/PrefillingTextInput.js'),
   preloaderCircular: require('!raw-loader!../../../examples/PreloaderCircular.js'),
   progressBars: require('!raw-loader!../../../examples/ProgressBars.js'),

--- a/docs/src/routes.js
+++ b/docs/src/routes.js
@@ -9,6 +9,7 @@ import CollapsiblePage from './pages/CollapsiblesPage';
 import DropdownPage from './pages/DropdownPage';
 import MediaPage from './pages/MediaPage';
 import ModalsPage from './pages/ModalsPage';
+import ParallaxPage from './pages/ParallaxPage';
 import SideNavPage from './pages/SideNavPage';
 import TabsPage from './pages/TabsPage';
 import ToastPage from './pages/ToastPage';
@@ -38,6 +39,7 @@ const jsComponents = {
   dropdown: DropdownPage,
   media: MediaPage,
   modals: ModalsPage,
+  parallax: ParallaxPage,
   sidenav: SideNavPage,
   tabs: TabsPage,
   toast: ToastPage

--- a/examples/Parallax.js
+++ b/examples/Parallax.js
@@ -4,12 +4,12 @@ import Parallax from '../src/Parallax';
 
 export default
 <div>
-  <Parallax imgSrc="http://materializecss.com/images/parallax1.jpg"/>
-  <div class="section white">
-    <div class="row container">
-      <h2 class="header">Parallax</h2>
-      <p class="grey-text text-darken-3 lighten-3">Parallax is an effect where the background content or image in this case, is moved at a different speed than the foreground content while scrolling.</p>
+  <Parallax imageSrc="http://materializecss.com/images/parallax1.jpg"/>
+  <div className="section white">
+    <div className="row container">
+      <h2 className="header">Parallax</h2>
+      <p className="grey-text text-darken-3 lighten-3">Parallax is an effect where the background content or image in this case, is moved at a different speed than the foreground content while scrolling.</p>
     </div>
   </div>
-  <Parallax imgSrc="http://materializecss.com/images/parallax2.jpg"/>
+  <Parallax imageSrc="http://materializecss.com/images/parallax2.jpg"/>
 </div>;


### PR DESCRIPTION
Fixed the prop name of `imageSrc` in the parallax example and added a parallax page in the docs and in `routes.js` so that the documentation shows properly. The description for the parallax component was taken from the materializecss website. 