### PR TITLE
Set `idx` in constructor

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -10,6 +10,7 @@ const classes = {
 class Dropdown extends Component {
   constructor (props) {
     super(props);
+    this.idx = 'dropdown_' + idgen();
     this.renderTrigger = this.renderTrigger.bind(this);
   }
 
@@ -25,7 +26,6 @@ class Dropdown extends Component {
 
   render () {
     const { children, className, ...props } = this.props;
-    this.idx = 'dropdown_' + idgen();
     delete props.trigger;
     delete props.options;
 

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -31,4 +31,13 @@ describe('<Dropdown />', () => {
     let output = `<ul class="dropdown-content more" id="dropdown_0"></ul>`;
     assert.equal(wrapper.find('ul').html(), output);
   });
+
+  it('does not update ID reference with each render', () => {
+    const wrapper = new Dropdown({ trigger: (<option>hi</option>) });
+    wrapper.render();
+    const firstId = wrapper.idx;
+    wrapper.render();
+    const secondId = wrapper.idx;
+    assert.equal(firstId, secondId);
+  });
 });


### PR DESCRIPTION
Otherwise we get a new ID with every render, but `componentWillMount` is not run meaning we don't attach the appropriate triggers.

Not sure about the test, `shallow.update()` wasn't triggering a re-render as its supposed to.