### PR TITLE
Init modals which have no trigger

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -12,11 +12,8 @@ class Modal extends Component {
   }
 
   componentDidMount () {
-    const { trigger, modalOptions } = this.props;
-
-    if (!trigger) {
-      $(`#${this.modalID}`).modal(modalOptions);
-    }
+    const { modalOptions } = this.props;
+    $(`#${this.modalID}`).modal(modalOptions);
   }
 
   renderOverlay () {


### PR DESCRIPTION
Hi, the modals of the sample page were not work, because which have not be initialized.