### PR TITLE
[Input] Prefix icon for date and select inputs

### DIFF
--- a/docs/src/pages/FormsPage.js
+++ b/docs/src/pages/FormsPage.js
@@ -14,6 +14,7 @@ import inputDatepicker from '../../../examples/InputDatePicker';
 import inputSwitch from '../../../examples/InputSwitch';
 import prefillingTextInput from '../../../examples/PrefillingTextInput';
 import selectSimple from '../../../examples/SelectSimple';
+import SelectWithIcon from '../../../examples/SelectWithIcon';
 import Code from '!raw-loader!Input';
 
 const header = 'Forms';
@@ -44,6 +45,10 @@ const FormsPage = () => (
       <Section>
         <h4 className='col s12'>Select</h4>
         <ReactPlayground code={require('!raw-loader!../../../examples/SelectSimple.js')} />
+
+        <p className='col s12'>You can also add a prop icon with its name to the Input tag, it will be shown as icon prefix</p>
+
+        <ReactPlayground code={require('!raw-loader!../../../examples/SelectWithIcon.js')} />
       </Section>
 
       <Section>

--- a/examples/SelectWithIcon.js
+++ b/examples/SelectWithIcon.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Input from '../src/Input';
+import Row from '../src/Row';
+
+export default
+  <Row>
+    <Input s={12} type='select' label='Materialize Select' icon='weekend' defaultValue='2'>
+      <option value='1'>Option 1</option>
+      <option value='2'>Option 2</option>
+      <option value='3'>Option 3</option>
+    </Input>
+  </Row>;

--- a/src/Input.js
+++ b/src/Input.js
@@ -143,6 +143,7 @@ class Input extends Component {
 
       return (
         <div className={cx(classes)}>
+          { this.renderIcon() }
           {htmlLabel}
           <select
             {...other}
@@ -162,6 +163,7 @@ class Input extends Component {
 
       return (
         <div className={cx(classes)}>
+          { this.renderIcon() }
           <C
             {...other}
             className={cx(className, inputClasses)}

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -60,7 +60,7 @@ describe('<Input />', () => {
 
     beforeEach(() => {
       wrapper = mount(
-        <Input type='select' defaultValue='v'>
+        <Input type='select' defaultValue='v' icon='weekend'>
           {values.map((val) => <option value={val} />)}
         </Input>
       );
@@ -76,6 +76,22 @@ describe('<Input />', () => {
 
     it('sets the isSelect to true', () => {
       expect(wrapper.instance().isSelect()).to.equal(true);
+    });
+
+    it('renders an icon child with prefix class', () => {
+      expect(wrapper.find(Icon).hasClass('prefix')).to.equal(true);
+    });
+
+    context('without icon', () => {
+      it('does not render with an icon child', () => {
+        const component = mount(
+          <Input type='select' defaultValue='v'>
+            <option value='v' />
+          </Input>
+        );
+
+        expect(component.find(Icon).exists()).to.equal(false);
+      });
     });
 
     context('with placeholder', () => {
@@ -142,6 +158,18 @@ describe('<Input />', () => {
       expect(pickadateStub).to.have.been.calledWith(options);
       pickadateStub.restore();
     });
+
+    it('renders a datepicker with icon', () => {
+      const wrapper = mount(<Input type='date'><Icon>today</Icon></Input>);
+
+      expect(wrapper.find('i').hasClass('prefix')).to.equal(true);
+    });
+
+    it('renders a datepicker without icon', () => {
+      const wrapper = mount(<Input type='date' />);
+
+      expect(wrapper.find('i').exists()).to.equal(false);
+    });
   });
 
   context('with icon', () => {
@@ -155,6 +183,13 @@ describe('<Input />', () => {
     it('renders an icon if icon prop is defined', () => {
       wrapper = shallow(<Input icon='cloud' />);
       expect(wrapper.find(Icon).hasClass('prefix')).to.equal(true);
+    });
+  });
+
+  context('whithout icon', () => {
+    it('does not render an icon child if icon prop is not defined', () => {
+      const wrapper = shallow(<Input />);
+      expect(wrapper.find(Icon).exists()).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
* For select inputs just add a prop icon to the
  Input tag. (Added an example in docs)

* For date inputs just follow the normal
  adding an Icon tag to the children of Input tag

![screen shot 2017-10-05 at 11 31 55](https://user-images.githubusercontent.com/218034/31234419-3ef3a41c-a9c5-11e7-93ab-03c6379b1d50.png)
