### PR TITLE
Upgrade materialize-css to v0.100.2 and implement Time Picker

### DIFF
--- a/docs/src/pages/FormsPage.js
+++ b/docs/src/pages/FormsPage.js
@@ -67,6 +67,11 @@ const FormsPage = () => (
       </Section>
 
       <Section>
+        <h4 className='col s12'>Time Picker</h4>
+        <ReactPlayground code={require('!raw-loader!../../../examples/InputTimePicker.js')} />
+      </Section>
+
+      <Section>
         <h4 className='col s12'>Switch</h4>
         <ReactPlayground code={require('!raw-loader!../../../examples/InputSwitch.js')} />
       </Section>

--- a/examples/InputTimePicker.js
+++ b/examples/InputTimePicker.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Input from '../src/Input';
+import Row from '../src/Row';
+
+export default
+<Row>
+  <Input name='on' type='time' onChange={function(e, value) {}} />
+</Row>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,15 +1263,6 @@
       "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
       "dev": true
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
-    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3461,18 +3452,6 @@
         }
       }
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
-    },
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
@@ -4365,14 +4344,13 @@
       }
     },
     "materialize-css": {
-      "version": "0.98.2",
-      "resolved": "https://registry.npmjs.org/materialize-css/-/materialize-css-0.98.2.tgz",
-      "integrity": "sha1-+eQjn9J+KpF6DeN5101Qji2S7I4=",
+      "version": "0.100.2",
+      "resolved": "https://registry.npmjs.org/materialize-css/-/materialize-css-0.100.2.tgz",
+      "integrity": "sha512-Bf4YeoJCIdk4dlpnmVX+DIOJBbqOKwfBPD+tT5bxwXNFMLk649CGbldqtnctkkfMp+fGgSAsdYu9lo1ZolZqgA==",
       "dev": true,
       "requires": {
         "hammerjs": "2.0.8",
-        "jquery": "2.2.4",
-        "node-archiver": "0.3.0"
+        "jquery": "2.2.4"
       }
     },
     "memory-fs": {
@@ -4530,16 +4508,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-archiver": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/node-archiver/-/node-archiver-0.3.0.tgz",
-      "integrity": "sha1-ufGv5QBtC98pJgGBgzoHCXi8aUc=",
-      "dev": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "tar": "2.2.1"
-      }
     },
     "node-fetch": {
       "version": "1.7.1",
@@ -5535,17 +5503,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
       "dev": true
-    },
-    "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "jsdom": "^9.9.1",
     "jsdom-global": "^2.1.1",
-    "materialize-css": "^0.98.0",
+    "materialize-css": "^0.100.2",
     "mocha": "^3.2.0",
     "react-addons-test-utils": "^15.4.2",
     "sinon": "^1.17.7",

--- a/src/Input.js
+++ b/src/Input.js
@@ -27,6 +27,10 @@ class Input extends Component {
       $(this.dateInput).pickadate(this.props.options);
       $(this.dateInput).on('change', this._onChange);
     }
+    if (this.isTimePicker) {
+      $(this.timeInput).pickatime(this.props.options);
+      $(this.timeInput).on('change', this._onChange);
+    }
   }
 
   componentDidUpdate () {
@@ -172,6 +176,25 @@ class Input extends Component {
             ref={(ref) => (this.dateInput = ref)}
             placeholder={placeholder}
             type='date'
+          />
+          {htmlLabel}
+        </div>
+      );
+    } else if (type === 'time') {
+      this.isTimePicker = true;
+      delete other.options;
+
+      return (
+        <div className={cx(classes)}>
+          { this.renderIcon() }
+          <C
+            {...other}
+            className={cx(className, inputClasses)}
+            defaultValue={defaultValue}
+            id={this._id}
+            ref={(ref) => (this.timeInput = ref)}
+            placeholder={placeholder}
+            type='time'
           />
           {htmlLabel}
         </div>

--- a/src/Input.js
+++ b/src/Input.js
@@ -194,7 +194,6 @@ class Input extends Component {
             id={this._id}
             ref={(ref) => (this.timeInput = ref)}
             placeholder={placeholder}
-            type='time'
           />
           {htmlLabel}
         </div>

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -172,6 +172,29 @@ describe('<Input />', () => {
     });
   });
 
+  context('#timepicker', () => {
+    it('renders a timepicker', () => {
+      const pickatimeStub = sinon.stub($.fn, 'pickatime');
+      const options = { one: 'two' };
+      mount(<Input type='time' options={options} />);
+
+      expect(pickatimeStub).to.have.been.calledWith(options);
+      pickatimeStub.restore();
+    });
+
+    it('renders a timepicker with icon', () => {
+      const wrapper = mount(<Input type='time'><Icon>today</Icon></Input>);
+
+      expect(wrapper.find('i').hasClass('prefix')).to.equal(true);
+    });
+
+    it('renders a timepicker without icon', () => {
+      const wrapper = mount(<Input type='time' />);
+
+      expect(wrapper.find('i').exists()).to.equal(false);
+    });
+  });
+
   context('with icon', () => {
     let wrapper;
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -13,5 +13,6 @@ global.$.fn.sideNav = () => this;
 global.$.fn.collapsible = () => this;
 global.$.fn.modal = () => this;
 global.$.fn.pickadate = () => this;
+global.$.fn.pickatime = () => this;
 global.$.fn.carousel = () => this;
 global.$.fn.dropdown = () => this;


### PR DESCRIPTION
I've updated the materialize-css package to its latest version which adds support for time picker.

Time Picker has been implemented as well and examples added to the documentation.

I've pulled it into another project and it appears to be working correctly however I'm reasonably new to React so may have missed something obvious.