### PR TITLE
Fix for #411

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -242,7 +242,7 @@ class Input extends Component {
       return <Icon className='prefix'>{icon}</Icon>;
     } else {
       let icon = null;
-      if (React.Children.count(children) === 1) {
+      if (React.Children.count(children) === 1 && !Array.isArray(children)) {
         icon = React.Children.only(children);
       }
       return icon === null ? null : React.cloneElement(icon, {className: 'prefix'});

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -125,6 +125,20 @@ describe('<Input />', () => {
         expect(wrapper.find('select').prop('multiple')).to.equal(true);
       });
     });
+
+    context('with only one option', () => {
+      it('renders a select with only one option', () => {
+        let options = [<option value='1' key='1' >Option 1</option>];
+        wrapper = mount(
+          <Input type='select' defaultValue='v'>
+            { options }
+          </Input>
+        );
+
+        expect(wrapper.find('select')).to.have.length(1);
+        expect(wrapper.find('option').length).to.equal(options.length);
+      });
+    });
   });
 
   context('#switch', () => {


### PR DESCRIPTION
Fix #411 

Added check to test that children wasn't an array in `renderIcon`. See #411 for details.