### PR TITLE
TimePicker fix for examples 

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -194,6 +194,7 @@ class Input extends Component {
             id={this._id}
             ref={(ref) => (this.timeInput = ref)}
             placeholder={placeholder}
+            type='time'
           />
           {htmlLabel}
         </div>


### PR DESCRIPTION
The time picker in the example docs isn't working because the `type='time'` attribute was somehow removed/left out of `src/Input.js` when it was committed/merged in.

This just adds it back in.
