### PR TITLE
Fix datepicker reopening issue

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -25,13 +25,7 @@ class Input extends Component {
       $(this.selectInput).on('change', this._onChange);
     }
     if (this.isDatePicker) {
-      $(this.dateInput).pickadate({...this.props.options, onClose: function() {
-          if(this.props.options.onClose) {
-            this.props.options.onClose();
-          }
-          $(document.activeElement).blur()
-        }
-      });
+      $(this.dateInput).pickadate(this.props.options);
       $(this.dateInput).on('change', this._onChange);
     }
     if (this.isTimePicker) {

--- a/src/Input.js
+++ b/src/Input.js
@@ -25,7 +25,13 @@ class Input extends Component {
       $(this.selectInput).on('change', this._onChange);
     }
     if (this.isDatePicker) {
-      $(this.dateInput).pickadate(this.props.options);
+      $(this.dateInput).pickadate({...this.props.options, onClose: function() {
+          if(this.props.options.onClose) {
+            this.props.options.onClose();
+          }
+          $(document.activeElement).blur()
+        }
+      });
       $(this.dateInput).on('change', this._onChange);
     }
     if (this.isTimePicker) {

--- a/src/Input.js
+++ b/src/Input.js
@@ -25,7 +25,14 @@ class Input extends Component {
       $(this.selectInput).on('change', this._onChange);
     }
     if (this.isDatePicker) {
-      $(this.dateInput).pickadate(this.props.options);
+      let { options } = this.props;
+      $(this.dateInput).pickadate({...options,
+        onClose: function () {
+          if (options.onClose) {
+            options.onClose();
+          }
+          $(document.activeElement).blur();
+        }});
       $(this.dateInput).on('change', this._onChange);
     }
     if (this.isTimePicker) {

--- a/src/Input.js
+++ b/src/Input.js
@@ -31,7 +31,7 @@ class Input extends Component {
           if (options.onClose) {
             options.onClose();
           }
-          $(document.activeElement).blur();
+          $(this.dateInput).blur();
         }});
       $(this.dateInput).on('change', this._onChange);
     }


### PR DESCRIPTION
# Description

The Input.js file from src folder has been changed. In `componentDidMount` while initializing pickadate there has been changes in the arguments. Additional `onClose` function is sent along with `options` where `onClose` function is called when user closes the date picker modal. This function blur the focused input element which causes the date picker modal reopening issue. The #468 issue has been solved with these changes. 
PS: This library is great for material design in react environment.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this by building the repo and adding that built module to another project. It worked fine but I could not write the test case for this because there are lots of library like (sinon, chai) that are used which I am unfamiliar with. So I left this part to the other expert contributors.

# Checklist:

- [ ] My changes break one test case
