### PR TITLE
Controlled modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+- Adds `open` prop to Modal allowing it to 'opened' to mount
+
 ## 2.0.6
 
 - Updates to materialize-css@0.100.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "files": [

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -20,11 +20,13 @@ class Modal extends Component {
   }
 
   componentDidMount () {
-    const { trigger, modalOptions } = this.props;
+    const { trigger, modalOptions, open } = this.props;
 
     if (!trigger) {
       $(`#${this.modalID}`).modal(modalOptions);
     }
+
+    if (open) this.showModal();
   }
 
   componentWillUnmount () {
@@ -66,9 +68,10 @@ class Modal extends Component {
   }
 
   showModal (e) {
-    e.preventDefault();
+    if (e) e.preventDefault();
     const { modalOptions = {} } = this.props;
-    $(`#${this.modalID}`).modal(modalOptions).modal('open');
+    $(`#${this.modalID}`).modal(modalOptions);
+    $(`#${this.modalID}`).modal('open');
   }
 
   render () {
@@ -122,6 +125,10 @@ Modal.propTypes = {
      */
     complete: PropTypes.func
   }),
+  /**
+  * Modal is opened on mount
+  */
+  open: PropTypes.bool,
   /**
   * BottomSheet styled modal
   * @default false

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -16,7 +16,7 @@ describe('<Modal />', () => {
 
   let wrapper;
   let renderedWrapper;
-  const modalStub = stub($.fn, 'modal');
+  let modalStub;
 
   context('renders a modal', () => {
     beforeEach(() => {
@@ -66,11 +66,13 @@ describe('<Modal />', () => {
 
   context('controlled modal with `open` prop', () => {
     beforeEach(() => {
-      wrapper = mount(<Modal modalOptions={{'one': 1}} open>{children}</Modal>);
+      modalStub = stub($.fn, 'modal');
+      mount(<Modal modalOptions={{'one': 1}} open>{children}</Modal>);
     });
 
     afterEach(() => {
       document.body.removeChild(document.body.lastElementChild);
+      modalStub.restore();
     });
 
     it('mounts opened', () => {
@@ -81,6 +83,7 @@ describe('<Modal />', () => {
 
   context('renders a trigger', () => {
     beforeEach(() => {
+      modalStub = stub($.fn, 'modal');
       wrapper = shallow(
         <Modal
           trigger={trigger}
@@ -92,11 +95,17 @@ describe('<Modal />', () => {
       );
     });
 
+    afterEach(() => {
+      document.body.removeChild(document.body.lastElementChild);
+      modalStub.restore();
+    });
+
     it('renders', () => {
       expect(wrapper.find('button').length).to.equal(1);
     });
 
     it('initializes with modalOptions', () => {
+      wrapper.find('button').simulate('click');
       expect(modalStub).to.have.been.calledWith(modalOptions);
     });
   });

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -55,8 +55,27 @@ describe('<Modal />', () => {
       );
     });
 
+    afterEach(() => {
+      document.body.removeChild(document.body.lastElementChild);
+    });
+
     it('renders', () => {
       expect(wrapper.find(Modal).length).to.equal(1);
+    });
+  });
+
+  context('controlled modal with `open` prop', () => {
+    beforeEach(() => {
+      wrapper = mount(<Modal modalOptions={{'one': 1}} open>{children}</Modal>);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(document.body.lastElementChild);
+    });
+
+    it('mounts opened', () => {
+      // once in mount and twice in #showModal
+      expect(modalStub).to.have.been.calledThrice;
     });
   });
 


### PR DESCRIPTION
# Description

Modal needs to be a controlled component, therefor it can accept `open` prop to be opened on mount.

Fixes #493 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

With 'open' prop, expect modalStub to be called thrice.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have not generated a new package version. (the maintainers will handle that)
