### PR TITLE
Controlled modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -34,6 +34,12 @@ class Modal extends Component {
     this.modalRoot = null;
   }
 
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.open) {
+      this.showModal();
+    }
+  }
+
   renderModalPortal () {
     const {
       actions,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -37,6 +37,8 @@ class Modal extends Component {
   componentWillReceiveProps (nextProps) {
     if (nextProps.open) {
       this.showModal();
+    } else if (nextProps.open === false) {
+      this.hideModal();
     }
   }
 
@@ -78,6 +80,13 @@ class Modal extends Component {
     const { modalOptions = {} } = this.props;
     $(`#${this.modalID}`).modal(modalOptions);
     $(`#${this.modalID}`).modal('open');
+  }
+
+  hideModal (e) {
+    if (e) e.preventDefault();
+    const { modalOptions = {} } = this.props;
+    $(`#${this.modalID}`).modal(modalOptions);
+    $(`#${this.modalID}`).modal('close');
   }
 
   render () {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -35,6 +35,7 @@ class Modal extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    // if the modal is not open yet
     if (!this.props.open && nextProps.open) {
       this.showModal();
     } else if (nextProps.open === false) {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -35,7 +35,7 @@ class Modal extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.open) {
+    if (!this.props.open && nextProps.open) {
       this.showModal();
     } else if (nextProps.open === false) {
       this.hideModal();

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -65,9 +65,10 @@ describe('<Modal />', () => {
   });
 
   context('controlled modal with `open` prop', () => {
+    let testModal;
     beforeEach(() => {
       modalStub = stub($.fn, 'modal');
-      mount(<Modal modalOptions={{'one': 1}} open>{children}</Modal>);
+      testModal = mount(<Modal modalOptions={{'one': 1}} open>{children}</Modal>);
     });
 
     afterEach(() => {
@@ -78,6 +79,11 @@ describe('<Modal />', () => {
     it('mounts opened', () => {
       // once in mount and twice in #showModal
       expect(modalStub).to.have.been.calledThrice;
+    });
+
+    it('open on prop change', () => {
+      testModal.setProps({ open: true });
+      expect(modalStub).to.have.callCount(5);
     });
   });
 

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -84,6 +84,15 @@ describe('<Modal />', () => {
     it('open on prop change', () => {
       testModal.setProps({ open: true });
       expect(modalStub).to.have.callCount(5);
+      expect(modalStub.firstCall.args[0]).to.deep.equal({ 'one': 1 });
+      expect(modalStub.lastCall.args).to.deep.equal([ 'open' ]);
+    });
+
+    it('closes on prop change', () => {
+      testModal.setProps({ open: false });
+      expect(modalStub).to.have.callCount(5);
+      expect(modalStub.firstCall.args[0]).to.deep.equal({ 'one': 1 });
+      expect(modalStub.lastCall.args).to.deep.equal([ 'close' ]);
     });
   });
 

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -84,6 +84,7 @@ describe('<Modal />', () => {
     it('open on prop change', () => {
       testModal.setProps({ open: true });
       expect(modalStub).to.have.been.calledThrice;
+      // expect showModal to pass modalOptions to $.modal
       expect(modalStub.firstCall.args[0]).to.deep.equal({ 'one': 1 });
       expect(modalStub.lastCall.args).to.deep.equal([ 'open' ]);
     });
@@ -91,6 +92,7 @@ describe('<Modal />', () => {
     it('closes on prop change', () => {
       testModal.setProps({ open: false });
       expect(modalStub).to.have.callCount(5);
+      // expect hideModal to pass modalOptions to $.modal
       expect(modalStub.firstCall.args[0]).to.deep.equal({ 'one': 1 });
       expect(modalStub.lastCall.args).to.deep.equal([ 'close' ]);
     });

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -83,7 +83,7 @@ describe('<Modal />', () => {
 
     it('open on prop change', () => {
       testModal.setProps({ open: true });
-      expect(modalStub).to.have.callCount(5);
+      expect(modalStub).to.have.been.calledThrice;
       expect(modalStub.firstCall.args[0]).to.deep.equal({ 'one': 1 });
       expect(modalStub.lastCall.args).to.deep.equal([ 'open' ]);
     });


### PR DESCRIPTION
# Description

Allow modal to open when the open property is set after initial component mount.  Added ability to close modal by setting the open prop to false.  This is a small fix to the feature added in #493

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added an additional test case to ModalSpec.js, and strengthened the existing test from #493 
verifies showModal is only called when the modal is no open by expecting three calls to stub.
tests that first call to $.modal receives modalOptions
tests that last call to $.modal stub passes 'open' or 'close' as only argument.


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
