### PR TITLE
Fix for issue 399

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -146,7 +146,7 @@ class Input extends Component {
       : null;
 
     if (this.isSelect()) {
-      let options = placeholder && !defaultValue ? [<option disabled key={idgen()}>{placeholder}</option>] : [];
+      let options = placeholder && !label && !defaultValue ? [<option disabled key={idgen()}>{placeholder}</option>] : [];
       options = options.concat(React.Children.map(children, (child) =>
         React.cloneElement(child, { 'key': child.props.value })
       ));


### PR DESCRIPTION
# Description

This fix is for the issue 399 https://github.com/react-materialize/react-materialize/issues/399.
When a placeholder is specified in the input, the label collides with the placeholder initially. 
To fix it, I am using the same technique you guys are using to prevent the label from colliding with any default value.
For rendering of the placeholder, I am adding the condition that no labels should be present, to the ternary operator.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

None  of the test cases are breaking, since I only added one more condition to an already existing ternary operator

# Checklist:

- [  ] I have commented my code, particularly in hard-to-understand areas
- [  ] My changes generate no new warnings
- [  ] I have not generated a new package version. (the maintainers will handle that)
