### PR TITLE
Fix for issue 399

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -136,7 +136,7 @@ class Input extends Component {
 
     let htmlLabel = label || inputType === 'radio'
       ? <label
-        className={cx(labelClasses, labelClassName)}
+        className={cx(labelClasses, labelClassName, {'active': placeholder})}
         data-success={success}
         data-error={error}
         htmlFor={this._id}

--- a/src/Input.js
+++ b/src/Input.js
@@ -131,12 +131,12 @@ class Input extends Component {
         inputType = type || 'text';
     }
     let labelClasses = {
-      active: this.state.value || this.isSelect()
+      active: this.state.value || this.isSelect() || placeholder
     };
-
+    
     let htmlLabel = label || inputType === 'radio'
       ? <label
-        className={cx(labelClasses, labelClassName, {'active': placeholder})}
+        className={cx(labelClasses, labelClassName)}
         data-success={success}
         data-error={error}
         htmlFor={this._id}


### PR DESCRIPTION
# Description

This PR fixes the issue https://github.com/react-materialize/react-materialize/issues/399.
I am adding the class 'active' when a placeholder is present in an input, so the label does not collide with the placeholder
## Type of change



- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since I am only adding a class. And the result is only visual without any change in the mark up, or logic, I have not added a unit test. None of the existing tests are failing.

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
