### PR TITLE
Resolve Issue #160 // Input Does Not Support Offset

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -93,6 +93,7 @@ class Input extends Component {
       s,
       m,
       l,
+      offset,
       type,
       validate,
       onLabel,
@@ -110,6 +111,11 @@ class Input extends Component {
     constants.SIZES.forEach(size => {
       classes[size + sizes[size]] = sizes[size];
     });
+    if (offset) {
+      offset.split(' ').forEach(off => {
+        classes['offset-' + off] = true;
+      });
+    }
     let inputClasses = {
       validate,
       invalid: error,
@@ -133,7 +139,6 @@ class Input extends Component {
     let labelClasses = {
       active: this.state.value || this.isSelect() || placeholder
     };
-    
     let htmlLabel = label || inputType === 'radio'
       ? <label
         className={cx(labelClasses, labelClassName)}
@@ -288,6 +293,7 @@ Input.propTypes = {
   s: PropTypes.number,
   m: PropTypes.number,
   l: PropTypes.number,
+  offset: PropTypes.string,
   inline: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { assert } from 'chai';
 import sinon from 'sinon';
 
 import Input from '../src/Input';
@@ -49,6 +50,33 @@ describe('<Input />', () => {
       expect(input.length).to.eql(1);
       expect(input.prop('id')).to.eql(label.prop('htmlFor'));
       expect(label.hasClass(labelClassName)).to.eql(true);
+    });
+  });
+
+  context('#text with sizes', () => {
+    it('accepts sizes as props', () => {
+      const wrapper = shallow(
+        <Input s={4} m={6} l={8} />
+      );
+      assert(wrapper.find('.col').hasClass('s4 m6 l8'), 'a column');
+    });
+  });
+
+  context('#text with sizes and one offset', () => {
+    it('accepts sizes as props', () => {
+      const wrapper = shallow(
+        <Input s={4} m={6} l={8} offset={'s4'} />
+      );
+      assert(wrapper.find('.col').hasClass('s4 m6 l8 offset-s4'), 'a column');
+    });
+  });
+
+  context('#text with sizes and multiple offsets', () => {
+    it('accepts sizes as props', () => {
+      const wrapper = shallow(
+        <Input s={4} m={6} l={8} offset={'s4 m2 l2'} />
+      );
+      assert(wrapper.find('.col').hasClass('s4 m6 l8 offset-s4 offset-m2 offset-l2'), 'a column');
     });
   });
 


### PR DESCRIPTION
# Description

I've added the Prop 'offset' to the Input component so that one can offset the input's parent column.

## Type of change

- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update

# How Has This Been Tested?

I created new tests within the test/InputSpec.js to ensure that you can either specify zero, one, or multiple offsets as long as the offset prop exists.

# Checklist:

- [ x ] My changes generate no new warnings
- [ x ] I have not generated a new package version. (the maintainers will handle that)
