### PR TITLE
Timepicker and Datepicker fix (issue-513)

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 
 require('../assets/stylesheets/ghpages-materialize.css');
+require('materialize-css/dist/css/materialize.css')
 require('../assets/stylesheets/main.css');
 
 import App from './components/App';


### PR DESCRIPTION
# Description

The Timepicker is not getting displayed as expected. 
The reason was, materialise.css was not getting imported in the index.js of the docs folder, and some of the styles in the ghpages-materialize.css (which is being imported) are different from the styles in materialise.css for the same classes, and so are overriding the styles from materialise.css.
 This caused the timepicker to break, and some of the styles of the datepicker to also not work as expected.

I have imported materialize-css/dist/css/materialize.min.css in the index.js of the docs folder to fix it, and everything is working fine.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since I'm importing a file to fix the issue, no unit tests are required.

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
