### PR TITLE
add onClick suport for NavItem component #465

### DIFF
--- a/examples/RightAlignedNavbar.js
+++ b/examples/RightAlignedNavbar.js
@@ -3,7 +3,7 @@ import Navbar from '../src/Navbar';
 import NavItem from '../src/NavItem';
 
 export default
-<Navbar brand='logo' right>
-  <NavItem href='get-started.html'>Getting started</NavItem>
-  <NavItem href='components.html'>Components</NavItem>
-</Navbar>;
+  <Navbar brand='logo' right>
+    <NavItem onClick={() => console.log('test click')}>Getting started</NavItem>
+    <NavItem href='components.html'>Components</NavItem>
+  </Navbar>;

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -9,9 +9,9 @@ const NavItem = ({
   ...props
 }) => {
   if (divider) return <li className='divider' />;
-  const a = onClick ? <a>{children}</a> : <a href={href}>{children}</a>;
+  const a = onClick ? <a onClick={onClick}>{children}</a> : <a href={href}>{children}</a>;
   return (
-    <li {...props} onClick={onClick}>
+    <li {...props}>
       {a}
     </li>
   );

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -5,14 +5,14 @@ const NavItem = ({
   divider,
   children,
   href = '',
+  onClick,
   ...props
 }) => {
   if (divider) return <li className='divider' />;
+  const a = onClick ? <a>{children}</a> : <a href={href}>{children}</a>;
   return (
-    <li {...props}>
-      <a href={href}>
-        { children }
-      </a>
+    <li {...props} onClick={onClick}>
+      {a}
     </li>
   );
 };
@@ -26,7 +26,12 @@ NavItem.propTypes = {
     PropTypes.node
   ]),
   divider: PropTypes.bool,
-  href: PropTypes.string
+  href: PropTypes.string,
+  /**
+   * NavItem can have onClick. If it does have, href
+   * will not be rendered
+   */
+  onClick: PropTypes.func
 };
 
 export default NavItem;

--- a/test/NavItemSpec.js
+++ b/test/NavItemSpec.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import NavItem from '../src/NavItem';
 
 describe('<NavItem />', () => {
@@ -50,5 +51,26 @@ describe('<NavItem />', () => {
 
     expect(wrapper.find('span').length).to.eq(1);
     expect(wrapper.find('h2').length).to.eq(1);
+  });
+
+  it('passes onClick as parameter', () => {
+    const onClick = sinon.spy();
+    wrapper = shallow(
+      <NavItem onClick={onClick} href='get-started.html'>Getting</NavItem>
+    );
+
+    expect(wrapper.props().onClick).to.be.ok;
+    expect(wrapper.props().onClick).to.eq(onClick);
+    wrapper.find('li').simulate('click');
+    expect(onClick.calledOnce).to.equal(true);
+    expect(wrapper.children().at(0).prop('href')).to.be.undefined;
+  });
+
+  it('passes href as parameter', () => {
+    wrapper = shallow(
+      <NavItem href='get-started.html'>Getting</NavItem>
+    );
+    expect(wrapper.children().at(0).prop('href')).to.be.ok;
+    expect(wrapper.children().at(0).prop('href')).to.eq('get-started.html');
   });
 });

--- a/test/NavItemSpec.js
+++ b/test/NavItemSpec.js
@@ -59,9 +59,9 @@ describe('<NavItem />', () => {
       <NavItem onClick={onClick} href='get-started.html'>Getting</NavItem>
     );
 
-    expect(wrapper.props().onClick).to.be.ok;
-    expect(wrapper.props().onClick).to.eq(onClick);
-    wrapper.find('li').simulate('click');
+    expect(wrapper.children().at(0).props().onClick).to.be.ok;
+    expect(wrapper.children().at(0).props().onClick).to.eq(onClick);
+    wrapper.children().at(0).simulate('click');
     expect(onClick.calledOnce).to.equal(true);
     expect(wrapper.children().at(0).prop('href')).to.be.undefined;
   });


### PR DESCRIPTION
# Description

Added onClick suport for NavItem, suggested on issue #465. Also suggested by @alextrastero that href should be removed when onClick is present on NavItem, this way onClick will work without interference from href.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested adding onClick only to NavItem. onClick should works normal
- Tested adding onClick and href to NavItem. onClick should works well and href is removed so it will not cause interference to onClick execution
- Tested adding only href to NavItem. Href should be executed normally
- Tested with no onClick nor href. No error shown

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)