### PR TITLE
Feature fixed sidenav

### DIFF
--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -15,13 +15,10 @@ class SideNav extends Component {
   }
 
   render() {
-    const { className, children, ...props } = this.props;
+    const { className, children, trigger, fixed, ...props } = this.props;
     delete props.id;
-    delete props.trigger;
     delete props.options;
-    delete props.fixed;
-    const fixed = this.props.fixed || !this.props.trigger;
-    const classNames = cx('side-nav', { fixed }, className);
+    const classNames = cx('side-nav', { fixed: fixed || !trigger }, className);
 
     return (
       <span>

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -22,6 +22,9 @@ class SideNav extends Component {
     delete props.showOnLarge;
 
     const classNames = cx('side-nav', { fixed }, className);
+    if (!this.props.trigger && !this.props.fixed) {
+      console.warn('No trigger was passed for the SideNav object. If no trigger was desired, please pass `fixed` to view your SideNav');
+    }
 
     return (
       <span>

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -15,17 +15,17 @@ class SideNav extends Component {
   }
 
   render() {
-    const { className, children, fixed, ...props } = this.props;
+    const { className, children, ...props } = this.props;
     delete props.id;
     delete props.trigger;
     delete props.options;
-    delete props.showOnLarge;
-
+    delete props.fixed;
+    const fixed = this.props.fixed || !this.props.trigger;
     const classNames = cx('side-nav', { fixed }, className);
 
     return (
       <span>
-        {this.props.trigger && this.renderTrigger()}
+        {this.renderTrigger()}
         <ul id={this.id} className={classNames} {...props}>
           {children}
         </ul>
@@ -34,11 +34,12 @@ class SideNav extends Component {
   }
 
   renderTrigger() {
-    const { trigger } = this.props;
-    const showOnLarge = this.props.showOnLarge
-      ? 'show-on-large'
-      : 'hide-on-large-only';
-    const classNames = cx(trigger.props.className, showOnLarge);
+    const { trigger, fixed } = this.props;
+    if (!trigger) {
+      return;
+    }
+    const triggerView = fixed ? 'hide-on-large-only' : 'show-on-large';
+    const classNames = cx(trigger.props.className, triggerView);
     return React.cloneElement(trigger, {
       ref: t => (this._trigger = `[data-activates=${this.id}]`),
       'data-activates': this.id,
@@ -52,10 +53,6 @@ SideNav.propTypes = {
    * Adds fixed class to side-nav
    */
   fixed: PropTypes.bool,
-  /**
-   * Adds showOnLarge class to Trigger
-   */
-  showOnLarge: PropTypes.bool,
   /**
    * sidenav id. If none is passed, an id will be generated.
    */

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -22,9 +22,6 @@ class SideNav extends Component {
     delete props.showOnLarge;
 
     const classNames = cx('side-nav', { fixed }, className);
-    if (!this.props.trigger && !this.props.fixed) {
-      console.warn('No trigger was passed for the SideNav object. If no trigger was desired, please pass `fixed` to view your SideNav');
-    }
 
     return (
       <span>
@@ -38,7 +35,9 @@ class SideNav extends Component {
 
   renderTrigger() {
     const { trigger } = this.props;
-    const showOnLarge = this.props.showOnLarge ? 'show-on-large' : 'hide-on-large-only';
+    const showOnLarge = this.props.showOnLarge
+      ? 'show-on-large'
+      : 'hide-on-large-only';
     const classNames = cx(trigger.props.className, showOnLarge);
     return React.cloneElement(trigger, {
       ref: t => (this._trigger = `[data-activates=${this.id}]`),

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -19,12 +19,13 @@ class SideNav extends Component {
     delete props.id;
     delete props.trigger;
     delete props.options;
+    delete props.showOnLarge;
 
     const classNames = cx('side-nav', { fixed }, className);
 
     return (
       <span>
-        { this.renderTrigger() }
+        { this.props.trigger && this.renderTrigger() }
         <ul id={this.id} className={classNames} {...props}>
           {children}
         </ul>
@@ -34,9 +35,12 @@ class SideNav extends Component {
 
   renderTrigger () {
     const { trigger } = this.props;
+    const showOnLarge = this.props.showOnLarge ? 'show-on-large' : 'hide-on-large-only';
+    const classNames = cx(trigger.props.className, showOnLarge);
     return React.cloneElement(trigger, {
       ref: (t) => (this._trigger = `[data-activates=${this.id}]`),
-      'data-activates': this.id
+      'data-activates': this.id,
+      className: classNames
     });
   }
 }
@@ -47,13 +51,17 @@ SideNav.propTypes = {
    */
   fixed: PropTypes.bool,
   /**
+   * Adds showOnLarge class to Trigger
+   */
+  showOnLarge: PropTypes.bool,
+  /**
    * sidenav id. If none is passed, an id will be generated.
    */
   id: PropTypes.string,
   /**
    * Component that is rendered to trigger the sidenav
    */
-  trigger: PropTypes.node.isRequired,
+  trigger: PropTypes.node,
   /**
    * Options hash for the sidenav.
    * More info: http://materializecss.com/side-nav.html#options

--- a/test/SideNavSpec.js
+++ b/test/SideNavSpec.js
@@ -42,6 +42,11 @@ describe('<SideNav />', () => {
     assert.isTrue(sideNav.hasClass('side-nav fixed red'));
   });
 
+  it('should render trigger on large screens if `showOnLarge`', () => {
+    const { trigger } = setup({className: 'green', showOnLarge: true});
+    assert.isTrue(trigger.hasClass('trigger show-on-large'));
+  });
+
   it('should render a given id', () => {
     const { sideNavProps, triggerProps } = setup({ id: 'test' });
     assert.equal(sideNavProps.id, 'test');

--- a/test/SideNavSpec.js
+++ b/test/SideNavSpec.js
@@ -46,9 +46,22 @@ describe('<SideNav />', () => {
     assert.isTrue(sideNav.hasClass('side-nav fixed red'));
   });
 
-  it('should render trigger on large screens if `showOnLarge`', () => {
-    const { trigger } = setup({ className: 'green', showOnLarge: true });
+  it('should render fixed if not passed trigger or fixed', () => {
+    const { wrapper } = setup({ className: 'red' });
+    const trigger = wrapper.find('trigger');
+    assert.isTrue(trigger.length === 0);
+  });
+
+  it('should render trigger on large screens not fixed`', () => {
+    const { trigger } = setup({ className: 'green' });
     assert.isTrue(trigger.hasClass('trigger show-on-large'));
+  });
+
+  it('should be fixed if no trigger is passed', () => {
+    const component = <SideNav className="red" />;
+    const wrapper = shallow(component);
+    const sideNav = wrapper.find('.side-nav');
+    assert.isTrue(sideNav.hasClass('side-nav fixed red'));
   });
 
   it('should render a given id', () => {

--- a/test/SideNavSpec.js
+++ b/test/SideNavSpec.js
@@ -47,7 +47,7 @@ describe('<SideNav />', () => {
   });
 
   it('should render trigger on large screens if `showOnLarge`', () => {
-    const { trigger } = setup({className: 'green', showOnLarge: true});
+    const { trigger } = setup({ className: 'green', showOnLarge: true });
     assert.isTrue(trigger.hasClass('trigger show-on-large'));
   });
 


### PR DESCRIPTION
# Description
This pull request is meant to allow the SideNav to be fixed as well as show the SideNav trigger on Large Displays. This should fix Issue #416  


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update (Add showOnLarge to SideNav PropTypes
https://react-materialize.github.io/#/sidenav)

# How Has This Been Tested?

Using the example SideNav in the docs, I used create-react-app to build a test application. I imported and initiated the SideNav. After passing a fixed prop to SideNav, the navigation stayed fixed and the trigger is not visible. If a trigger is passed with fixed, it will display the trigger on mobile only. While passing the showOnLarge prop, I can now see the trigger on Large Displays as well as mobile. 

All tests were passing without adjustment. I added an extra test for the showOnLarge prop. 

I also removed the isRequired on trigger prop. The only problem here is, there is no error if you do not pass a trigger. To resolve this, I added a console.warn that lets the developer know there was no trigger passed to SideNav.


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
