### PR TITLE
Corrected typo in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
-First of all thanks for contributing!, by participating
+First of all, thanks for contributing! By participating
 you agree to abide by the [code of conduct](https://github.com/react-materialize/react-materialize/blob/master/CODE_OF_CONDUCT.md).
 <br/>
 Now that you've spent a couple hours reading let's get down to business.


### PR DESCRIPTION
# Description

This is only a change to documentation! Corrected the typo shown below:

<img width="786" alt="screen shot 2018-04-20 at 11 56 26 am" src="https://user-images.githubusercontent.com/16906897/39061375-0a600b9c-4492-11e8-8fbb-1f727188fa07.png">



