### PR TITLE
React Router DOM and similar integration in NavItem

### DIFF
--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -7,13 +7,19 @@ class NavItem extends Component {
 
     if (divider) return <li className="divider" />;
 
-    const a = onClick ? (
-      <a onClick={onClick}>{children}</a>
-    ) : (
-      <a href={href}>{children}</a>
-    );
+    let content;
 
-    return <li {...other}>{a}</li>;
+    if (typeof children !== 'string') {
+      content = { ...children };
+    } else {
+      content = onClick ? (
+        <a onClick={onClick}>{children}</a>
+      ) : (
+        <a href={href}>{children}</a>
+      );
+    }
+
+    return <li {...other}>{content}</li>;
   }
 }
 

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,15 +1,21 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const NavItem = ({ divider, children, href = '', onClick, ...props }) => {
-  if (divider) return <li className="divider" />;
-  const a = onClick ? (
-    <a onClick={onClick}>{children}</a>
-  ) : (
-    <a href={href}>{children}</a>
-  );
-  return <li {...props}>{a}</li>;
-};
+class NavItem extends Component {
+  render() {
+    const { divider, children, href, onClick, ...other } = this.props;
+
+    if (divider) return <li className="divider" />;
+
+    const a = onClick ? (
+      <a onClick={onClick}>{children}</a>
+    ) : (
+      <a href={href}>{children}</a>
+    );
+
+    return <li {...other}>{a}</li>;
+  }
+}
 
 NavItem.propTypes = {
   /**
@@ -23,6 +29,10 @@ NavItem.propTypes = {
    * will not be rendered
    */
   onClick: PropTypes.func
+};
+
+NavItem.defaultProps = {
+  href: ''
 };
 
 export default NavItem;


### PR DESCRIPTION
# Description

Now it's possible to use different children for NavItem.
For example:
-   `<NavItem href='components.html'>Components</NavItem>` will be rendered as before
-    `<NavItem><Link to="/">Home</Link></NavItem>`  will be correctly rendered with react-router-dom and similar

This fix the #188 issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I've used the component without problems in another project.

# Checklist:

- [ ] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
