### PR TITLE
Added the possibility to transition FAB into a toolbar

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -65,8 +65,8 @@ class Button extends Component {
     }
   }
 
-  renderFab(className, orientation, clickOnly) {
-    const classes = cx(orientation, clickOnly);
+  renderFab(className, mode, clickOnly) {
+    const classes = cx(mode, clickOnly);
     return (
       <div className={cx('fixed-action-btn', classes)}>
         <a className={className}>{this.renderIcon()}</a>
@@ -102,7 +102,7 @@ Button.propTypes = {
    * If enabled, any children button will be rendered as actions, remember to provide an icon.
    * @default vertical. This will disable any onClick function from being called on the main button.
    */
-  fab: PropTypes.oneOf(['vertical', 'horizontal']),
+  fab: PropTypes.oneOf(['vertical', 'horizontal', 'toolbar']),
   /**
    * The icon to display, if specified it will create a button with the material icon.
    */


### PR DESCRIPTION
# Description

Instead of displaying individual button options, there is now the possibility to transtion a FAB into a toolbar on click.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I've used this component in a project.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
