### PR TITLE
consolidates main module root import/exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,87 +1,42 @@
-import Autocomplete from './Autocomplete';
-import Badge from './Badge';
-import Breadcrumb from './Breadcrumb';
-import Button from './Button';
-import Carousel from './Carousel';
-import Card from './Card';
-import CardPanel from './CardPanel';
-import CardTitle from './CardTitle';
-import Chip from './Chip';
-import Col from './Col';
-import Collapsible from './Collapsible';
-import CollapsibleItem from './CollapsibleItem';
-import Collection from './Collection';
-import CollectionItem from './CollectionItem';
-import Container from './Container';
-import Divider from './Divider';
-import Dropdown from './Dropdown';
-import Footer from './Footer';
-import Icon from './Icon';
-import Input from './Input';
-import MediaBox from './MediaBox';
-import MenuItem from './MenuItem';
-import Modal from './Modal';
-import NavItem from './NavItem';
-import Navbar from './Navbar';
-import Pagination from './Pagination';
-import PaginationButton from './PaginationButton';
-import Parallax from './Parallax';
-import Preloader from './Preloader';
-import ProgressBar from './ProgressBar';
-import Row from './Row';
-import SearchForm from './SearchForm';
-import Section from './Section';
-import SideNav from './SideNav';
-import SideNavItem from './SideNavItem';
-import Slide from './Slide';
-import Slider from './Slider';
-import Tab from './Tab';
-import Table from './Table';
-import Tabs from './Tabs';
-import Tag from './Tag';
-import Toast from './Toast';
-
-export {
-  Autocomplete,
-  Badge,
-  Breadcrumb,
-  Button,
-  Carousel,
-  Card,
-  CardPanel,
-  CardTitle,
-  Chip,
-  Col,
-  Collapsible,
-  CollapsibleItem,
-  Collection,
-  CollectionItem,
-  Container,
-  Divider,
-  Dropdown,
-  Footer,
-  Icon,
-  Input,
-  MediaBox,
-  MenuItem,
-  Modal,
-  NavItem,
-  Navbar,
-  Pagination,
-  PaginationButton,
-  Parallax,
-  Preloader,
-  ProgressBar,
-  Row,
-  SearchForm,
-  Section,
-  SideNav,
-  SideNavItem,
-  Slide,
-  Slider,
-  Tab,
-  Table,
-  Tabs,
-  Tag,
-  Toast
-};
+export { default as Autocomplete } from './Autocomplete';
+export { default as Badge } from './Badge';
+export { default as Breadcrumb } from './Breadcrumb';
+export { default as Button } from './Button';
+export { default as Carousel } from './Carousel';
+export { default as Card } from './Card';
+export { default as CardPanel } from './CardPanel';
+export { default as CardTitle } from './CardTitle';
+export { default as Chip } from './Chip';
+export { default as Col } from './Col';
+export { default as Collapsible } from './Collapsible';
+export { default as CollapsibleItem } from './CollapsibleItem';
+export { default as Collection } from './Collection';
+export { default as CollectionItem } from './CollectionItem';
+export { default as Container } from './Container';
+export { default as Divider } from './Divider';
+export { default as Dropdown } from './Dropdown';
+export { default as Footer } from './Footer';
+export { default as Icon } from './Icon';
+export { default as Input } from './Input';
+export { default as MediaBox } from './MediaBox';
+export { default as MenuItem } from './MenuItem';
+export { default as Modal } from './Modal';
+export { default as NavItem } from './NavItem';
+export { default as Navbar } from './Navbar';
+export { default as Pagination } from './Pagination';
+export { default as PaginationButton } from './PaginationButton';
+export { default as Parallax } from './Parallax';
+export { default as Preloader } from './Preloader';
+export { default as ProgressBar } from './ProgressBar';
+export { default as Row } from './Row';
+export { default as SearchForm } from './SearchForm';
+export { default as Section } from './Section';
+export { default as SideNav } from './SideNav';
+export { default as SideNavItem } from './SideNavItem';
+export { default as Slide } from './Slide';
+export { default as Slider } from './Slider';
+export { default as Tab } from './Tab';
+export { default as Table } from './Table';
+export { default as Tabs } from './Tabs';
+export { default as Tag } from './Tag';
+export { default as Toast } from './Toast';


### PR DESCRIPTION
# Description

DRY's up top-level exports and allows dropping of unused modules in cases where tree-shaking is not supported or configured by importing components directly i.e. `import Button from "react-materialize/Button"`.

[Material-UI](https://github.com/mui-org/material-ui/blob/v1-beta/packages/material-ui/src/index.js), [Ant-Design](https://github.com/ant-design/ant-design/blob/master/components/index.tsx), and [React-Toolbox](https://github.com/react-toolbox/react-toolbox/blob/dev/components/index.js) all use this pattern in their top-level exports and Material-UI has even [written about it in detail in their docs](https://material-ui-next.com/guides/minimizing-bundle-size/).

Bundle-size reduction with minimal webpack config:

|                    | static             | parsed         | gzip                | bundle-analyzer |
| ------------- | --------------: | -------------: | --------------: | ------------------------------------- |
| __before__         | 280.87 KB    | 176.67 KB    | 42.93 KB        | ![before.png](https://github.com/tyler-reitz/react-materialize-sandbox/blob/master/webpack-bundle-analysis/before.png "Logo Title Text 1")  |
| __after__            | 133.23 KB    | 110.1 KB      | 34.72 KB        | ![after.png](https://github.com/tyler-reitz/react-materialize-sandbox/blob/master/webpack-bundle-analysis/after.png) |
| __reduction__ |  52%             | 37%             | 19%               |  -- |

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

This wouldn't "break" existing functionality as the full API is still exposed at the top level for convenience. However, I did see an increase in final bundle size when importing the entire library using the current named import syntax i.e. `import { Button, Icon } from "react-materialize"` so marking as _breaking_ since there's a possible increase in bundle size.

# How Has This Been Tested?

I did not add a spec as there were none to begin with for the top-level module however the current test suite passes. I was able to manually test things locally by building and importing both directly from the components and top-level API.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
