### PR TITLE
Including the option to change the active tab indicator color

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -34,6 +34,8 @@ class Tabs extends Component {
 
     const scope = `${idgen()}`;
 
+    const indicatorColor = `indicator ${this.props.indicatorColor}`
+
     return (
       <Row>
         <Col s={12}>
@@ -69,6 +71,7 @@ class Tabs extends Component {
                 </li>
               );
             })}
+            <div class={indicatorColor} style={{zIndex: 1}}></div>
           </ul>
         </Col>
         {React.Children.map(children, (child, id) => {
@@ -97,6 +100,7 @@ Tabs.propTypes = {
   className: PropTypes.string,
   defaultValue: PropTypes.string,
   onChange: PropTypes.func,
+  indicatorColor: PropTypes.string,
   /*
    * More info
    * <a href='http://materializecss.com/tabs.html'>http://materializecss.com/tabs.html</a>

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -34,7 +34,10 @@ class Tabs extends Component {
 
     const scope = `${idgen()}`;
 
-    const indicatorColor = `indicator ${this.props.indicatorColor}`
+    let indicatorClasses = 'indicator';
+    if (this.props.indicatorClasses) {
+      indicatorClasses += ` ${this.props.indicatorClasses}`;
+    }
 
     return (
       <Row>
@@ -71,7 +74,7 @@ class Tabs extends Component {
                 </li>
               );
             })}
-            <div class={indicatorColor} style={{zIndex: 1}}></div>
+            <div className={indicatorClasses} style={{ zIndex: 1 }} />
           </ul>
         </Col>
         {React.Children.map(children, (child, id) => {
@@ -100,7 +103,7 @@ Tabs.propTypes = {
   className: PropTypes.string,
   defaultValue: PropTypes.string,
   onChange: PropTypes.func,
-  indicatorColor: PropTypes.string,
+  indicatorClasses: PropTypes.string,
   /*
    * More info
    * <a href='http://materializecss.com/tabs.html'>http://materializecss.com/tabs.html</a>

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -30,14 +30,9 @@ class Tabs extends Component {
   }
 
   render() {
-    const { children, className, defaultValue } = this.props;
+    const { children, className, defaultValue, indicatorClasses } = this.props;
 
     const scope = `${idgen()}`;
-
-    let indicatorClasses = 'indicator';
-    if (this.props.indicatorClasses) {
-      indicatorClasses += ` ${this.props.indicatorClasses}`;
-    }
 
     return (
       <Row>
@@ -74,7 +69,10 @@ class Tabs extends Component {
                 </li>
               );
             })}
-            <div className={indicatorClasses} style={{ zIndex: 1 }} />
+            <li
+              className={cx('indicator', indicatorClasses)}
+              style={{ zIndex: 1 }}
+            />
           </ul>
         </Col>
         {React.Children.map(children, (child, id) => {

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -103,6 +103,10 @@ Tabs.propTypes = {
   className: PropTypes.string,
   defaultValue: PropTypes.string,
   onChange: PropTypes.func,
+  /*
+   * Used to change the active tab classes
+   * e.g. indicatorClasses="grey lighten-4"
+   */
   indicatorClasses: PropTypes.string,
   /*
    * More info

--- a/test/__snapshots__/Tabs.spec.js.snap
+++ b/test/__snapshots__/Tabs.spec.js.snap
@@ -32,7 +32,7 @@ exports[`Tabs should create list of Tab itemt 1`] = `
           Two
         </a>
       </li>
-      <div
+      <li
         className="indicator"
         style={
           Object {

--- a/test/__snapshots__/Tabs.spec.js.snap
+++ b/test/__snapshots__/Tabs.spec.js.snap
@@ -32,6 +32,14 @@ exports[`Tabs should create list of Tab itemt 1`] = `
           Two
         </a>
       </li>
+      <div
+        className="indicator"
+        style={
+          Object {
+            "zIndex": 1,
+          }
+        }
+      />
     </ul>
   </Col>
   <Col


### PR DESCRIPTION
Including the option to change the active tab indicator color via materializecss classes

# Description

Title self explanatory.

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)
- [x ] This change requires a documentation update

# How Has This Been Tested?

Common change on projects using materializecss. Tested on local project and with npm test

# Checklist:

- [x ] My changes generate no new warnings
- [x ] I have not generated a new package version. (the maintainers will handle that)
