### PR TITLE
Do not show dropdown when an item has been selected

### DIFF
--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -11,7 +11,8 @@ class Autocomplete extends Component {
     super(props);
 
     this.state = {
-      value: props.value || ''
+      value: props.value || '',
+      itemSelected: false
     };
 
     this.renderIcon = this.renderIcon.bind(this);
@@ -30,9 +31,9 @@ class Autocomplete extends Component {
   }
 
   renderDropdown(data, minLength, limit) {
-    const { value } = this.state;
+    const { value, itemSelected } = this.state;
 
-    if ((minLength && minLength > value.length) || !value) {
+    if ((minLength && minLength > value.length) || !value || itemSelected) {
       return null;
     }
 
@@ -78,7 +79,7 @@ class Autocomplete extends Component {
       onChange(evt, value);
     }
 
-    this.setState({ value });
+    this.setState({ value, itemSelected: false });
   }
 
   _onAutocomplete(value, evt) {
@@ -90,7 +91,7 @@ class Autocomplete extends Component {
       onChange(evt, value);
     }
 
-    this.setState({ value });
+    this.setState({ value, itemSelected: true });
   }
 
   render() {

--- a/test/Autocomplete.spec.js
+++ b/test/Autocomplete.spec.js
@@ -54,7 +54,7 @@ describe('<Autocomplete />', () => {
     });
   });
 
-  describe('on dropdown select', () => {
+  describe('on dropdown first item select', () => {
     const expectedValue = 'Apple';
 
     beforeAll(() => {
@@ -64,6 +64,34 @@ describe('<Autocomplete />', () => {
       wrapper
         .find('ul li')
         .first()
+        .simulate('click');
+    });
+
+    test('updates the state with the new value', () => {
+      expect(wrapper.state('value')).toEqual(expectedValue);
+    });
+
+    test('adds clicked value to input', () => {
+      expect(wrapper.find('.autocomplete').prop('value')).toEqual(
+        expectedValue
+      );
+    });
+
+    test('hides other matches', () => {
+      expect(wrapper.find('.highlight').length).toEqual(0);
+    });
+  });
+
+  describe('on dropdown second item select', () => {
+    const expectedValue = 'Apple Inc';
+
+    beforeAll(() => {
+      wrapper
+        .find('.autocomplete')
+        .simulate('change', { target: { value: typedKey } });
+      wrapper
+        .find('ul li')
+        .last()
         .simulate('click');
     });
 

--- a/test/Autocomplete.spec.js
+++ b/test/Autocomplete.spec.js
@@ -5,7 +5,8 @@ import Autocomplete from '../src/Autocomplete';
 const data = {
   Apple: null,
   Microsoft: null,
-  Google: 'http://placehold.it/250x250'
+  Google: 'http://placehold.it/250x250',
+  'Apple Inc': null
 };
 
 const componentId = 'testAutocompleteId';
@@ -43,7 +44,13 @@ describe('<Autocomplete />', () => {
     });
 
     test("highlight's results", () => {
-      expect(wrapper.find('.highlight').text()).toEqual(typedKey);
+      expect(wrapper.find('.highlight').length).toEqual(2);
+      expect(
+        wrapper
+          .find('.highlight')
+          .first()
+          .text()
+      ).toEqual(typedKey);
     });
   });
 
@@ -54,7 +61,10 @@ describe('<Autocomplete />', () => {
       wrapper
         .find('.autocomplete')
         .simulate('change', { target: { value: typedKey } });
-      wrapper.find('ul li').simulate('click');
+      wrapper
+        .find('ul li')
+        .first()
+        .simulate('click');
     });
 
     test('updates the state with the new value', () => {
@@ -65,6 +75,10 @@ describe('<Autocomplete />', () => {
       expect(wrapper.find('.autocomplete').prop('value')).toEqual(
         expectedValue
       );
+    });
+
+    test('hides other matches', () => {
+      expect(wrapper.find('.highlight').length).toEqual(0);
     });
   });
 
@@ -105,7 +119,10 @@ describe('<Autocomplete />', () => {
     });
 
     test('adds clicked value to input', () => {
-      wrapper2.find('ul li').simulate('click');
+      wrapper2
+        .find('ul li')
+        .first()
+        .simulate('click');
 
       expect(wrapper2.find('.autocomplete').prop('value')).toEqual(
         expectedValue


### PR DESCRIPTION
# Description

Fixes issue #536 

Ensure the dropdown is hidden after selection when there are multiple matches for an autocomplete search term. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new test for multiple matches which checks that only a single item is displayed after selection.

# Checklist:

- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
