### PR TITLE
Make icon a class component

### DIFF
--- a/src/Icon.js
+++ b/src/Icon.js
@@ -3,20 +3,22 @@ import PropTypes from 'prop-types';
 import constants from './constants';
 import cx from 'classnames';
 
-const Icon = props => {
-  let classes = {
-    'material-icons': true
-  };
-  constants.PLACEMENTS.forEach(p => {
-    classes[p] = props[p];
-  });
-
-  constants.ICON_SIZES.forEach(s => {
-    classes[s] = props[s];
-  });
-
-  return <i className={cx(classes, props.className)}>{props.children}</i>;
-};
+class Icon extends React.Component {
+  render() {
+    const classes = {
+      'material-icons': true
+    };
+    constants.PLACEMENTS.forEach(p => {
+      classes[p] = this.props[p];
+    });
+    constants.ICON_SIZES.forEach(s => {
+      classes[s] = this.props[s];
+    });
+    return (
+      <i className={cx(classes, this.props.className)}>{this.props.children}</i>
+    );
+  }
+}
 
 Icon.propTypes = {
   /*


### PR DESCRIPTION
# Description

As Icon was a functional component, it couldn't be used as a "trigger" for a Dropdown.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The following code will not work without the PR.
```js
<Dropdown trigger={
    <Icon>more_vert</Icon>
}>
    <NavItem onClick={this.handleLogout}>LOGOUT</NavItem>
</Dropdown>
```

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
