### PR TITLE
FAB Button tweaks

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -59,16 +59,16 @@ class Button extends Component {
       classes['modal-' + modal] = true;
     }
     if (fab) {
-      const int = cx(classes, className);
-      const out = cx(fab, toggle, 'fixed-action-btn');
+      const button = cx(classes, className);
+      const parent = cx(fab, toggle, 'fixed-action-btn');
       return (
         <div
-          className={out}
+          className={parent}
           disabled={!!disabled}
           data-tooltip={tooltip}
           ref={el => (this._btnEl = el)}
         >
-          <a id={other.id} className={int}>{this.renderIcon()}</a>
+          <a id={other.id} className={button}>{this.renderIcon()}</a>
           <ul>
             {React.Children.map(this.props.children, child => {
               return <li key={idgen()}>{child}</li>;

--- a/src/Button.js
+++ b/src/Button.js
@@ -9,7 +9,6 @@ class Button extends Component {
   constructor(props) {
     super(props);
     this.renderIcon = this.renderIcon.bind(this);
-    this.renderFab = this.renderFab.bind(this);
   }
 
   componentDidMount() {
@@ -60,7 +59,23 @@ class Button extends Component {
       classes['modal-' + modal] = true;
     }
     if (fab) {
-      return this.renderFab(cx(classes, className), fab, toggle);
+      const int = cx(classes, className);
+      const out = cx(fab, toggle, 'fixed-action-btn');
+      return (
+        <div
+          className={out}
+          disabled={!!disabled}
+          data-tooltip={tooltip}
+          ref={el => (this._btnEl = el)}
+        >
+          <a id={other.id} className={int}>{this.renderIcon()}</a>
+          <ul>
+            {React.Children.map(this.props.children, child => {
+              return <li key={idgen()}>{child}</li>;
+            })}
+          </ul>
+        </div>
+      );
     } else {
       return (
         <C
@@ -76,20 +91,6 @@ class Button extends Component {
         </C>
       );
     }
-  }
-
-  renderFab(className, orientation, clickOnly) {
-    const classes = cx(orientation, clickOnly);
-    return (
-      <div className={cx('fixed-action-btn', classes)}>
-        <a className={className}>{this.renderIcon()}</a>
-        <ul>
-          {React.Children.map(this.props.children, child => {
-            return <li key={idgen()}>{child}</li>;
-          })}
-        </ul>
-      </div>
-    );
   }
 
   renderIcon() {

--- a/src/Button.js
+++ b/src/Button.js
@@ -9,6 +9,7 @@ class Button extends Component {
   constructor(props) {
     super(props);
     this.renderIcon = this.renderIcon.bind(this);
+    this.renderFab = this.renderFab.bind(this);
   }
 
   componentDidMount() {
@@ -59,23 +60,7 @@ class Button extends Component {
       classes['modal-' + modal] = true;
     }
     if (fab) {
-      const button = cx(classes, className);
-      const parent = cx(fab, toggle, 'fixed-action-btn');
-      return (
-        <div
-          className={parent}
-          disabled={!!disabled}
-          data-tooltip={tooltip}
-          ref={el => (this._btnEl = el)}
-        >
-          <a id={other.id} className={button}>{this.renderIcon()}</a>
-          <ul>
-            {React.Children.map(this.props.children, child => {
-              return <li key={idgen()}>{child}</li>;
-            })}
-          </ul>
-        </div>
-      );
+      return this.renderFab(cx(classes, className), fab, toggle);
     } else {
       return (
         <C
@@ -91,6 +76,20 @@ class Button extends Component {
         </C>
       );
     }
+  }
+
+  renderFab(className, orientation, clickOnly) {
+    const classes = cx(orientation, clickOnly);
+    return (
+      <div className={cx('fixed-action-btn', classes)}>
+        <a className={className}>{this.renderIcon()}</a>
+        <ul>
+          {React.Children.map(this.props.children, child => {
+            return <li key={idgen()}>{child}</li>;
+          })}
+        </ul>
+      </div>
+    );
   }
 
   renderIcon() {

--- a/src/Button.js
+++ b/src/Button.js
@@ -9,7 +9,6 @@ class Button extends Component {
   constructor(props) {
     super(props);
     this.renderIcon = this.renderIcon.bind(this);
-    this.renderFab = this.renderFab.bind(this);
   }
 
   componentDidMount() {
@@ -60,7 +59,23 @@ class Button extends Component {
       classes['modal-' + modal] = true;
     }
     if (fab) {
-      return this.renderFab(cx(classes, className), fab, toggle);
+      const button = cx(classes, className);
+      const parent = cx(fab, toggle, 'fixed-action-btn');
+      return (
+        <div
+          className={parent}
+          disabled={!!disabled}
+          data-tooltip={tooltip}
+          ref={el => (this._btnEl = el)}
+        >
+          <a id={other.id} className={button}>{this.renderIcon()}</a>
+          <ul>
+            {React.Children.map(this.props.children, child => {
+              return <li key={idgen()}>{child}</li>;
+            })}
+          </ul>
+        </div>
+      );
     } else {
       return (
         <C
@@ -76,20 +91,6 @@ class Button extends Component {
         </C>
       );
     }
-  }
-
-  renderFab(className, orientation, clickOnly) {
-    const classes = cx(orientation, clickOnly);
-    return (
-      <div className={cx('fixed-action-btn', classes)}>
-        <a className={className}>{this.renderIcon()}</a>
-        <ul>
-          {React.Children.map(this.props.children, child => {
-            return <li key={idgen()}>{child}</li>;
-          })}
-        </ul>
-      </div>
-    );
   }
 
   renderIcon() {


### PR DESCRIPTION
Implements unhandled props for FAB buttons such as `disabled` and `tooltip*`.
In particular, an `id` has been added for a future implementation of [FeatureDiscovery](https://materializecss.com/feature-discovery.html).

_Note: I have not set a new package version._