### PR TITLE
 3.0.0 Icon.js

### DIFF
--- a/docs/src/pages/IconsPage.js
+++ b/docs/src/pages/IconsPage.js
@@ -12,12 +12,27 @@ const IconsPage = () => (
   <Row>
     <Col m={9} s={12} l={10}>
       <p className='caption'>
-        We have included 740 Material Design Icons courtesy of Google. You can download them directly from the
+        We have included 932 Material Design Icons courtesy of Google. You can download them directly from the
         {' '}
         <a href='http://google.github.io/material-design-icons/#icon-font-for-the-web' target='_blank'>
           Material Design specs
         </a>.
       </p>
+      <h4 className='col s12'>
+        Usage
+      </h4>
+      <Col s={12}>
+        <p>
+          To be able to use these icons, you must include this line in the
+          <code className=" language-markup">&lt;head&gt;</code>
+          portion of your HTML code
+        </p>
+        <pre className="language-markup">
+          <code className="language-markup">
+              &lt;link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"&gt;
+          </code>
+        </pre>
+      </Col>
       <h4 className='col s12'>
         Simple
       </h4>

--- a/test/Icon.spec.js
+++ b/test/Icon.spec.js
@@ -14,4 +14,8 @@ describe('<Icon />', () => {
     wrapper = shallow(<Icon large>cloud</Icon>);
     expect(wrapper).toMatchSnapshot();
   });
+  test('accepts placement as a prop', () => {
+    wrapper = shallow(<Icon left>cloud</Icon>);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/test/__snapshots__/Icon.spec.js.snap
+++ b/test/__snapshots__/Icon.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Icon /> accepts placement as a prop 1`] = `
+<i
+  className="material-icons left"
+>
+  cloud
+</i>
+`;
+
 exports[`<Icon /> accepts size as a prop 1`] = `
 <i
   className="material-icons large"


### PR DESCRIPTION
#595 I verified that Icons still work with version `1.0.0-rc.2` of the materialize style sheet, by creating a small project. Also added a small snapshot test to verify icons take placement as a prop. Slightly updated the documentation.

I know this is not a lot, but if anyone more creative than me can see anything that needs to be added, I will gladly give it a try :smile: 