### PR TITLE
Updated Slider for materialize 1.0.0 API #606

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -6,6 +6,8 @@ class Slider extends Component {
   constructor() {
     super();
     this.initSlider = this.initSlider.bind(this);
+    this.fullscreenReset = this.fullscreenReset.bind(this);
+    this.setActiveIndex = this.setActiveIndex.bind(this);
   }
 
   initSlider() {
@@ -18,26 +20,36 @@ class Slider extends Component {
     });
   }
 
+  /**
+   * If the slider was not in fullscreen, the height is set as a style attribute
+   * on the Slider element. When `.destroy()` is called, this attribute is not
+   * removed, resulting in a fullscreen displayed incorrectly.
+   */
+  fullscreenReset(was_fullscreen) {
+    if (!was_fullscreen && this.props.fullscreen) {
+      this.instance.el.removeAttribute('style');
+      this.instance.el.childNodes[0].removeAttribute('style');
+    }
+  }
+
+  setActiveIndex(activeIndex) {
+    if (this.props.indicators && activeIndex)
+      this.instance['$indicators'][activeIndex].className =
+        'indicator-item active';
+  }
+
   componentDidMount() {
     this.initSlider();
   }
 
   componentDidUpdate(prevProps) {
-    if (this.instance) {
-      this.instance.destroy();
-      var activeIndex = this.instance.activeIndex;
-      // When instance is destroyed, the style attribute which determines the
-      // height of the slider is not removed, making the fullscreen incorrect height
-      if (prevProps.fullscreen === false && this.props.fullscreen) {
-        this.instance.el.removeAttribute('style');
-        this.instance.el.childNodes[0].removeAttribute('style');
-      }
-      this.initSlider();
-      // keep indicator at current index displayed
-      if (this.props.indicators && activeIndex)
-        this.instance['$indicators'][activeIndex].className =
-          'indicator-item active';
-    }
+    if (!this.instance) return;
+    const active_index = this.instance.activeIndex;
+    this.instance.destroy();
+    this.fullscreenReset(prevProps.fullscreen);
+    this.initSlider();
+    // keep indicator at current index displayed
+    this.setActiveIndex(active_index);
   }
 
   componentWillUnmount() {

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -4,14 +4,19 @@ import cx from 'classnames';
 
 class Slider extends Component {
   componentDidMount() {
-    const { fullscreen, indicators, interval, transition } = this.props;
-
-    $('.slider').slider({
-      full_width: fullscreen,
+    const { indicators, interval, duration, height } = this.props;
+    this.instance = M.Slider.init(this._slider, {
       indicators,
       interval,
-      transition
+      duration,
+      height
     });
+  }
+
+  componentWillUnmount() {
+    if (this.instance) {
+      this.instance.destroy();
+    }
   }
 
   render() {
@@ -22,7 +27,10 @@ class Slider extends Component {
     };
 
     return (
-      <div className={cx(classes, className)}>
+      <div
+        ref={node => (this._slider = node)}
+        className={cx(classes, className)}
+      >
         <ul className="slides">{children}</ul>
       </div>
     );
@@ -47,13 +55,20 @@ Slider.propTypes = {
    * The duration of the transation animation in ms
    * @default 500
    */
-  transition: PropTypes.number
+  duration: PropTypes.number,
+  /**
+   * The height of the Slider window
+   * @default 400
+   */
+  height: PropTypes.number
 };
 
 Slider.defaultProps = {
   fullscreen: false,
   indicators: true,
-  interval: 6000
+  interval: 6000,
+  duration: 500,
+  height: 400
 };
 
 export default Slider;

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 class Slider extends Component {
-  componentDidMount() {
+  constructor() {
+    super();
+    this.initSlider = this.initSlider.bind(this);
+  }
+
+  initSlider() {
     const { indicators, interval, duration, height } = this.props;
     this.instance = M.Slider.init(this._slider, {
       indicators,
@@ -11,6 +16,28 @@ class Slider extends Component {
       duration,
       height
     });
+  }
+
+  componentDidMount() {
+    this.initSlider();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.instance) {
+      this.instance.destroy();
+      var activeIndex = this.instance.activeIndex;
+      // When instance is destroyed, the style attribute which determines the
+      // height of the slider is not removed, making the fullscreen incorrect height
+      if (prevProps.fullscreen === false && this.props.fullscreen) {
+        this.instance.el.removeAttribute('style');
+        this.instance.el.childNodes[0].removeAttribute('style');
+      }
+      this.initSlider();
+      // keep indicator at current index displayed
+      if (this.props.indicators && activeIndex)
+        this.instance['$indicators'][activeIndex].className =
+          'indicator-item active';
+    }
   }
 
   componentWillUnmount() {

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -3,21 +3,15 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 class Slider extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.initSlider = this.initSlider.bind(this);
     this.fullscreenReset = this.fullscreenReset.bind(this);
     this.setActiveIndex = this.setActiveIndex.bind(this);
   }
 
   initSlider() {
-    const { indicators, interval, duration, height } = this.props;
-    this.instance = M.Slider.init(this._slider, {
-      indicators,
-      interval,
-      duration,
-      height
-    });
+    this.instance = M.Slider.init(this._slider, this.props.options);
   }
 
   /**
@@ -25,17 +19,21 @@ class Slider extends Component {
    * on the Slider element. When `.destroy()` is called, this attribute is not
    * removed, resulting in a fullscreen displayed incorrectly.
    */
-  fullscreenReset(was_fullscreen) {
-    if (!was_fullscreen && this.props.fullscreen) {
+  fullscreenReset(wasFullscreen) {
+    if (!wasFullscreen && this.props.fullscreen) {
       this.instance.el.removeAttribute('style');
       this.instance.el.childNodes[0].removeAttribute('style');
     }
   }
 
   setActiveIndex(activeIndex) {
-    if (this.props.indicators && activeIndex)
+    let { indicators } = this.props.options;
+    // In case this option is not defined, we assume true, as per default
+    let showIndicators = typeof indicators === 'undefined' || indicators;
+    if (showIndicators && activeIndex) {
       this.instance['$indicators'][activeIndex].className =
         'indicator-item active';
+    }
   }
 
   componentDidMount() {
@@ -44,12 +42,12 @@ class Slider extends Component {
 
   componentDidUpdate(prevProps) {
     if (!this.instance) return;
-    const active_index = this.instance.activeIndex;
+    const activeIndex = this.instance.activeIndex;
     this.instance.destroy();
     this.fullscreenReset(prevProps.fullscreen);
     this.initSlider();
     // keep indicator at current index displayed
-    this.setActiveIndex(active_index);
+    this.setActiveIndex(activeIndex);
   }
 
   componentWillUnmount() {
@@ -79,35 +77,43 @@ class Slider extends Component {
 Slider.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  /**
+   * Whether or not the Slider should be fullscreen
+   * @default false
+   */
   fullscreen: PropTypes.bool,
-  /**
-   * Set to false to hide slide indicators
-   * @default true
-   */
-  indicators: PropTypes.bool,
-  /**
-   * The interval between transitions in ms
-   * @default 6000
-   */
-  interval: PropTypes.number,
-  /**
-   * The duration of the transation animation in ms
-   * @default 500
-   */
-  duration: PropTypes.number,
-  /**
-   * The height of the Slider window
-   * @default 400
-   */
-  height: PropTypes.number
+  options: PropTypes.shape({
+    /**
+     * Set to false to hide slide indicators
+     * @default true
+     */
+    indicators: PropTypes.bool,
+    /**
+     * The interval between transitions in ms
+     * @default 6000
+     */
+    interval: PropTypes.number,
+    /**
+     * The duration of the transation animation in ms
+     * @default 500
+     */
+    duration: PropTypes.number,
+    /**
+     * The height of the Slider window
+     * @default 400
+     */
+    height: PropTypes.number
+  })
 };
 
 Slider.defaultProps = {
   fullscreen: false,
-  indicators: true,
-  interval: 6000,
-  duration: 500,
-  height: 400
+  options: {
+    indicators: true,
+    interval: 6000,
+    duration: 500,
+    height: 400
+  }
 };
 
 export default Slider;

--- a/test/Slider.spec.js
+++ b/test/Slider.spec.js
@@ -1,19 +1,55 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Slider from '../src/Slider';
-import mocker from './helper/mocker';
+import mocker from './helper/new-mocker';
 
 describe('<Slider />', () => {
   let wrapper;
-  const sliderMock = jest.fn();
-  const restore = mocker('slider', sliderMock);
+  const sliderInitMock = jest.fn();
+  const sliderInstanceDestroyMock = jest.fn();
+  const sliderMock = {
+    init: (el, options) => {
+      sliderInitMock(options);
+      return {
+        destroy: sliderInstanceDestroyMock
+      };
+    }
+  };
+  const restore = mocker('Slider', sliderMock);
+
+  const defaultOptions = {
+    indicators: true,
+    interval: 6000,
+    duration: 500,
+    height: 400
+  };
+
+  beforeEach(() => {
+    sliderInitMock.mockClear();
+  });
 
   afterAll(() => {
     restore();
   });
 
+  test('initializes Slider with default options', () => {
+    wrapper = shallow(<Slider />);
+    expect(sliderInitMock).toHaveBeenCalledWith(defaultOptions);
+  });
+
+  test('Destroyed when unmounted', () => {
+    wrapper = shallow(<Slider />);
+    wrapper.unmount();
+    expect(sliderInstanceDestroyMock).toHaveBeenCalled();
+  });
+
   test('should render a Slider', () => {
     wrapper = shallow(<Slider />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  test('should render a fullscreen Slider', () => {
+    wrapper = shallow(<Slider fullscreen />);
+    expect(wrapper.hasClass('fullscreen'));
   });
 });

--- a/test/Slider.spec.js
+++ b/test/Slider.spec.js
@@ -57,4 +57,18 @@ describe('<Slider />', () => {
     wrapper = shallow(<Slider fullscreen />);
     expect(wrapper.hasClass('fullscreen'));
   });
+
+  test('update should destroy and re-initialize with new options', () => {
+    wrapper = shallow(<Slider />);
+    expect(sliderInitMock).toHaveBeenCalledWith(defaultOptions);
+    const nextProps = {
+      indicators: false,
+      interval: 500,
+      duration: 1000,
+      height: 500
+    };
+    wrapper.setProps(nextProps);
+    expect(sliderInstanceDestroyMock).toHaveBeenCalled();
+    expect(sliderInitMock.mock.calls[1][0]).toEqual(nextProps);
+  });
 });

--- a/test/Slider.spec.js
+++ b/test/Slider.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount, render } from 'enzyme';
 import Slider from '../src/Slider';
 import mocker from './helper/new-mocker';
 
@@ -11,7 +11,12 @@ describe('<Slider />', () => {
     init: (el, options) => {
       sliderInitMock(options);
       return {
-        destroy: sliderInstanceDestroyMock
+        destroy: sliderInstanceDestroyMock,
+        el: {
+          removeAttribute: jest.fn(),
+          childNodes: [{ removeAttribute: jest.fn() }]
+        },
+        $indicators: [{ className: 'indicator-item' }]
       };
     }
   };

--- a/test/Slider.spec.js
+++ b/test/Slider.spec.js
@@ -62,13 +62,15 @@ describe('<Slider />', () => {
     wrapper = shallow(<Slider />);
     expect(sliderInitMock).toHaveBeenCalledWith(defaultOptions);
     const nextProps = {
-      indicators: false,
-      interval: 500,
-      duration: 1000,
-      height: 500
+      options: {
+        indicators: false,
+        interval: 500,
+        duration: 1000,
+        height: 500
+      }
     };
     wrapper.setProps(nextProps);
     expect(sliderInstanceDestroyMock).toHaveBeenCalled();
-    expect(sliderInitMock.mock.calls[1][0]).toEqual(nextProps);
+    expect(sliderInitMock.mock.calls[1][0]).toEqual(nextProps.options);
   });
 });


### PR DESCRIPTION
## Type of change

Fixes #606. API for this component has slightly changed. Renamed `transition` prop to `duration`, because it has been renamed in materialize 1.0.0. Added `height` prop which is passed along as option.

# How Has This Been Tested?

Tested like in PR #616 mocking the `M.Slider.init()` call. Added a test for fullscreen. There are some intricacies with `materialize-css` when updating the properties, which I have been unable to test since the test setup don't actually use `materialize-css`.