### PR TITLE
Tabs reinitialization fix

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -29,6 +29,14 @@ class Tabs extends Component {
     }
   }
 
+  componentDidUpdate() {
+    const { tabOptions = {} } = this.props;
+
+    if (typeof $ !== 'undefined') {
+      $(this._tabsEl).tabs(tabOptions);
+    }
+  }
+
   render() {
     const { children, className, defaultValue } = this.props;
 


### PR DESCRIPTION
# Description

Fixed issue #633 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It doesn't need much testing - after <Tab>s are mounted and their childs' props are updated, tabs didn't reinitiate, which caused the same effects as the #498 issuse.

# Checklist:

- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
