### PR TITLE
updated Navbar component to 1.0.0-rc2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3678,12 +3678,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3698,17 +3700,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3825,7 +3830,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3837,6 +3843,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3851,6 +3858,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3858,12 +3866,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3882,6 +3892,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3962,7 +3973,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3974,6 +3986,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4095,6 +4108,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8167,12 +8181,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8192,7 +8208,8 @@
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -8340,6 +8357,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Col from './Col';
 import Icon from './Icon';
 
 class Navbar extends Component {
@@ -12,7 +11,7 @@ class Navbar extends Component {
 
   componentDidMount() {
     if (typeof $ !== 'undefined') {
-      $('.button-collapse').sideNav(this.props.options);
+      $('.button-collapse').sidenav(this.props.options);
     }
   }
 
@@ -25,9 +24,23 @@ class Navbar extends Component {
   }
 
   render() {
-    const { brand, className, fixed, left, right, href, ...other } = this.props;
+    const {
+      brand,
+      className,
+      fixed,
+      left,
+      right,
+      href,
+      container,
+      ...other
+    } = this.props;
 
     delete other.options;
+
+    let insideClasses = {
+      'nav-wrapper': true,
+      container: container
+    };
 
     let classes = {
       right: right,
@@ -41,17 +54,15 @@ class Navbar extends Component {
 
     let content = (
       <nav {...other} className={className}>
-        <div className="nav-wrapper">
-          <Col s={12}>
-            <a href={href} className={cx(brandClasses)}>
-              {brand}
-            </a>
-            <ul className={cx(className, classes)}>{this.props.children}</ul>
-            {this.renderSideNav()}
-            <a className="button-collapse" href="#" data-activates="nav-mobile">
-              <Icon>view_headline</Icon>
-            </a>
-          </Col>
+        <div className={cx(insideClasses)}>
+          <a href={href} className={cx(brandClasses)}>
+            {brand}
+          </a>
+          <ul className={cx(className, classes)}>{this.props.children}</ul>
+          {this.renderSideNav()}
+          <a className="button-collapse" href="#" data-activates="nav-mobile">
+            <Icon>view_headline</Icon>
+          </a>
         </div>
       </nav>
     );
@@ -71,6 +82,7 @@ Navbar.propTypes = {
   left: PropTypes.bool,
   right: PropTypes.bool,
   href: PropTypes.string,
+  container: PropTypes.string,
   /**
    * Makes the navbar fixed
    */

--- a/test/Navbar.spec.js
+++ b/test/Navbar.spec.js
@@ -7,7 +7,7 @@ import mocker from './helper/mocker';
 describe('<Navbar />', () => {
   let wrapper;
   const sideNavMock = jest.fn();
-  const restore = mocker('sideNav', sideNavMock);
+  const restore = mocker('sidenav', sideNavMock);
 
   afterAll(() => {
     restore();

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -16,44 +16,36 @@ exports[`<Navbar /> adds a brand node 1`] = `
     <div
       className="nav-wrapper"
     >
-      <Col
-        s={12}
+      <a
+        className="brand-logo"
+        href="/"
       >
-        <div
-          className="col s12"
+        <span
+          className="brando"
         >
-          <a
-            className="brand-logo"
-            href="/"
+          I AM BRAND
+        </span>
+      </a>
+      <ul
+        className="hide-on-med-and-down"
+      />
+      <ul
+        className="side-nav"
+        id="nav-mobile"
+      />
+      <a
+        className="button-collapse"
+        data-activates="nav-mobile"
+        href="#"
+      >
+        <Icon>
+          <i
+            className="material-icons"
           >
-            <span
-              className="brando"
-            >
-              I AM BRAND
-            </span>
-          </a>
-          <ul
-            className="hide-on-med-and-down"
-          />
-          <ul
-            className="side-nav"
-            id="nav-mobile"
-          />
-          <a
-            className="button-collapse"
-            data-activates="nav-mobile"
-            href="#"
-          >
-            <Icon>
-              <i
-                className="material-icons"
-              >
-                view_headline
-              </i>
-            </Icon>
-          </a>
-        </div>
-      </Col>
+            view_headline
+          </i>
+        </Icon>
+      </a>
     </div>
   </nav>
 </Navbar>
@@ -67,49 +59,10 @@ exports[`<Navbar /> can be fixed 1`] = `
     <div
       className="nav-wrapper"
     >
-      <Col
-        s={12}
-      >
-        <a
-          className="brand-logo"
-          href="/"
-        />
-        <ul
-          className="hide-on-med-and-down"
-        />
-        <ul
-          className="side-nav"
-          id="nav-mobile"
-        />
-        <a
-          className="button-collapse"
-          data-activates="nav-mobile"
-          href="#"
-        >
-          <Icon>
-            view_headline
-          </Icon>
-        </a>
-      </Col>
-    </div>
-  </nav>
-</div>
-`;
-
-exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
-<nav>
-  <div
-    className="nav-wrapper"
-  >
-    <Col
-      s={12}
-    >
       <a
-        className="brand-logo right"
+        className="brand-logo"
         href="/"
-      >
-        logo
-      </a>
+      />
       <ul
         className="hide-on-med-and-down"
       />
@@ -126,7 +79,38 @@ exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
           view_headline
         </Icon>
       </a>
-    </Col>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
+<nav>
+  <div
+    className="nav-wrapper"
+  >
+    <a
+      className="brand-logo right"
+      href="/"
+    >
+      logo
+    </a>
+    <ul
+      className="hide-on-med-and-down"
+    />
+    <ul
+      className="side-nav"
+      id="nav-mobile"
+    />
+    <a
+      className="button-collapse"
+      data-activates="nav-mobile"
+      href="#"
+    >
+      <Icon>
+        view_headline
+      </Icon>
+    </a>
   </div>
 </nav>
 `;
@@ -136,54 +120,50 @@ exports[`<Navbar /> renders 1`] = `
   <div
     className="nav-wrapper"
   >
-    <Col
-      s={12}
+    <a
+      className="brand-logo"
+      href="/"
     >
-      <a
-        className="brand-logo"
-        href="/"
+      Logo
+    </a>
+    <ul
+      className="right hide-on-med-and-down"
+    >
+      <NavItem
+        href="get-started.html"
       >
-        Logo
-      </a>
-      <ul
-        className="right hide-on-med-and-down"
+        Getting started
+      </NavItem>
+      <NavItem
+        href="components.html"
       >
-        <NavItem
-          href="get-started.html"
-        >
-          Getting started
-        </NavItem>
-        <NavItem
-          href="components.html"
-        >
-          Components
-        </NavItem>
-      </ul>
-      <ul
-        className="side-nav"
-        id="nav-mobile"
+        Components
+      </NavItem>
+    </ul>
+    <ul
+      className="side-nav"
+      id="nav-mobile"
+    >
+      <NavItem
+        href="get-started.html"
       >
-        <NavItem
-          href="get-started.html"
-        >
-          Getting started
-        </NavItem>
-        <NavItem
-          href="components.html"
-        >
-          Components
-        </NavItem>
-      </ul>
-      <a
-        className="button-collapse"
-        data-activates="nav-mobile"
-        href="#"
+        Getting started
+      </NavItem>
+      <NavItem
+        href="components.html"
       >
-        <Icon>
-          view_headline
-        </Icon>
-      </a>
-    </Col>
+        Components
+      </NavItem>
+    </ul>
+    <a
+      className="button-collapse"
+      data-activates="nav-mobile"
+      href="#"
+    >
+      <Icon>
+        view_headline
+      </Icon>
+    </a>
   </div>
 </nav>
 `;


### PR DESCRIPTION
# Description

updated Navbar.js component to 1.0.0-rc2 version of materialize, added the ability to add a 'container' prop that will add the className container to the wrapper div, also removed the Col Component from navbar as it is no longer needed, updated sidenav initialization from sideNav to sidenav as per 1.0.0-rc2 call

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update

# How Has This Been Tested?

ran npm test, updated snapshot, changed test mockup to point to new implementation name (SideNav to sidenav)

# Checklist:

- [ x] My changes generate no new warnings
- [ x] I have not generated a new package version. (the maintainers will handle that)
