### PR TITLE
Improve UI of the toast page in the docs

### DIFF
--- a/docs/assets/stylesheets/main.css
+++ b/docs/assets/stylesheets/main.css
@@ -60,3 +60,9 @@ ul.side-nav.fixed li.logo {
 ul.side-nav.fixed li.logo img {
   max-height: 100% !important;
 }
+
+.react-live-preview .toast {
+  top: 0;
+  float: none !important;
+  width: fit-content !important;
+}

--- a/docs/src/pages/ToastPage.js
+++ b/docs/src/pages/ToastPage.js
@@ -6,27 +6,34 @@ import PropTable from './PropTable';
 import Samples from './Samples';
 import toast from '../../../examples/Toast';
 import toastCode from '!raw-loader!Toast';
+
 const ToastPage = () => (
   <Row>
     <Col m={9} s={12} l={10}>
-      <p className='caption'>
-        Materialize provides an easy way for you to send unobtrusive alerts to your users through toasts.
-        These toasts are also placed and sized responsively,
-        try it out by clicking the button below on different device sizes.
+      <p className="caption">
+        Materialize provides an easy way for you to send unobtrusive alerts to
+        your users through toasts. These toasts are also placed and sized
+        responsively, try it out by clicking the button below on different
+        device sizes.
       </p>
       <Col s={12}>
-        <ReactPlayground code={Samples.toast}>
-          {toast}
-        </ReactPlayground>
+        <ReactPlayground code={Samples.toast}>{toast}</ReactPlayground>
       </Col>
-      <h5 className='col s12'>
-        Programmatic use
-      </h5>
+
       <Col s={12}>
+        <h5 className="col s12">Programmatic use</h5>
+        <p className="caption">
+          This section discusses how you can control a toast programmatically.
+        </p>
+        <blockquote className="caption">
+          Accessing Materialize  on the window object when firing a toast  isn't specific to{' '}
+          <a href="https://react-materialize.github.io">react-materialize</a>{' '}
+          it's part of how JavaScript treats variables on the global scope.
+        </blockquote>
         <ReactPlayground code={Samples.toastProgrammatically} />
       </Col>
       <Col s={12}>
-        <PropTable header='Toast' component={toastCode} />
+        <PropTable header="Toast" component={toastCode} />
       </Col>
     </Col>
   </Row>

--- a/examples/ToastProgrammatically.js
+++ b/examples/ToastProgrammatically.js
@@ -1,21 +1,24 @@
 import React from 'react';
 import Button from '../src/Button';
 
-export default
-<div>
-    <Button onClick={() => {
-            window.Materialize.toast('I am a toast!', 10000);
-        }
-    }>
-        Click to show
+export default 
+  <div>
+    <Button
+      onClick={() => {
+        window.Materialize.toast('I am a toast!', 10000);
+      }}
+    >
+      Show Toast
     </Button>
-    <Button onClick={() => {
-            const toast = document.querySelector('#toast-container>.toast');
-            if (toast) {
-                toast.remove();
-            }
+    {'  '}
+    <Button
+      onClick={() => {
+        const toast = document.querySelector('#toast-container>.toast');
+        if (toast) {
+          toast.remove();
         }
-    }>
-        Click to hide
+      }}
+    >
+      Hide Toast
     </Button>
-</div>
+  </div>

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -28,7 +28,13 @@ class Toast extends Component {
 
 Toast.propTypes = {
   className: PropTypes.string,
+  /**
+   * The message to display in the toast
+   */
   toast: PropTypes.string.isRequired,
+  /**
+   * The text to render in the button that fires the toast
+   */
   children: PropTypes.node,
   rounded: PropTypes.bool
 };

--- a/test/Toast.spec.js
+++ b/test/Toast.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Toast from '../src/Toast';
+describe('<Toast />', () => {
+  const wrappper = mount(<Toast toast="I am a toast">Toast</Toast>);
+  window.Materialize = { toast: jest.fn() };
+
+  it('renders properly', () => {
+    expect(wrappper).toMatchSnapshot();
+  });
+
+  it('should fire the toast on click', () => {
+    wrappper.find('button').simulate('click');
+    expect(window.Materialize.toast).toHaveBeenCalled();
+  });
+});

--- a/test/Toast.spec.js
+++ b/test/Toast.spec.js
@@ -3,7 +3,9 @@ import { mount } from 'enzyme';
 
 import Toast from '../src/Toast';
 describe('<Toast />', () => {
-  const wrappper = mount(<Toast toast="I am a toast">Toast</Toast>);
+  const toastMessage = 'I am a toast';
+  const toastTimeout = 1000;
+  const wrappper = mount(<Toast toast={toastMessage}>Toast</Toast>);
   window.Materialize = { toast: jest.fn() };
 
   it('renders properly', () => {
@@ -13,5 +15,9 @@ describe('<Toast />', () => {
   it('should fire the toast on click', () => {
     wrappper.find('button').simulate('click');
     expect(window.Materialize.toast).toHaveBeenCalled();
+    expect(window.Materialize.toast).toHaveBeenCalledWith(
+      toastMessage,
+      toastTimeout
+    );
   });
 });

--- a/test/__snapshots__/Toast.spec.js.snap
+++ b/test/__snapshots__/Toast.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Toast /> renders properly 1`] = `
+<Toast
+  toast="I am a toast"
+>
+  <Button
+    className="toast"
+    node="button"
+    onClick={[Function]}
+  >
+    <button
+      className="btn toast"
+      disabled={false}
+      onClick={[Function]}
+    >
+      Toast
+    </button>
+  </Button>
+</Toast>
+`;


### PR DESCRIPTION
# Description
- Add a description in the Programmatic use section
- Add a space in between the show and hide toast buttons and modify there text
- Add styles to the toast button in the live preview.
- Add a description of some props in the Toast component
- Add tests for the Toast component
Motivation - I wanted to make the page look better and add some description too it. For example, this is how the page looks before and after.
### Before
<img width="713" alt="screenshot 2018-09-02 at 08 31 03" src="https://user-images.githubusercontent.com/13004199/44952904-643dd700-ae93-11e8-82ae-c8cf768acf01.png">

### After
<img width="1190" alt="screen shot 2018-09-02 at 13 26 22" src="https://user-images.githubusercontent.com/13004199/44954959-d2929180-aeb3-11e8-8103-184696ea659a.png">


## Type of change
Documentation change and Add tests

# How Has This Been Tested?
- Manually by navigating to the Toast docs (to see changes in the docs)
- Automatically ( to see added tests ) by running
```sh
npm test Toast
```

# Checklist:

- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
