### PR TITLE
Supports both jQuery and JS initialization

### DIFF
--- a/test/DropdownButton.spec.js
+++ b/test/DropdownButton.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Dropdown from '../src/Dropdown';
+import Divider from '../src/Divider';
 import mocker from './helper/mocker';
 
 describe('<Dropdown />', () => {
@@ -36,5 +37,18 @@ describe('<Dropdown />', () => {
     const { idx } = wrapper.instance();
     wrapper.render();
     expect(wrapper.instance().idx).toEqual(idx);
+  });
+
+  test('does correctly render dividers', () => {
+    wrapper = shallow(
+      <Dropdown trigger={<span>hi</span>}>
+        <a href="#">test</a>
+        <Divider />
+        <a href="#">test</a>
+      </Dropdown>
+    );
+    const { idx } = wrapper.instance();
+    wrapper.render();
+    expect(wrapper.contains(<li className="divider" tanIndex="-1" />));
   });
 });

--- a/test/__snapshots__/DropdownButton.spec.js.snap
+++ b/test/__snapshots__/DropdownButton.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Dropdown /> renders 1`] = `
-<span>
+<Fragment>
   <button
     className="dropdown-trigger"
     data-target="dropdown_0"
@@ -12,5 +12,5 @@ exports[`<Dropdown /> renders 1`] = `
     className="dropdown-content"
     id="dropdown_0"
   />
-</span>
+</Fragment>
 `;


### PR DESCRIPTION
# Description

Supports both jQuery and JS initialization, new options added (as per the[ documentation](https://materializecss.com/dropdown.html)), new rendering methods implemented.

Dropping `<NavItem>`s in favour of a more classical but flexible approach.

This was a necessity for me, as I'm using React Router.

With this change the integration with React Router is as simple as : 

```
<Dropdown trigger={<Button>Drop Me!</Button>}>
     <Link to="/first">First link</Link>
     <Link to="/second">Second link</Link>
</Dropdown>
```
 Note that dropping `<NavItem>`s  lead me to introducing `<Divider>` component to render dividers inside Dropdown;

If you want to render a divider, this is the code you should write: 

```
<Dropdown trigger={<Button>Drop Me!</Button>}>
      <Link to="/first">First link</Link>
      <Divider />
      <Link to="/second">Second link</Link>
</Dropdown>
```

I think this is more semantic as well.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added a test to check if rendering `<Divider />` is correctly implemented;

Every other tests are okay

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
