### PR TITLE
3.0.0 latest materialize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6148,6 +6148,12 @@
         "merge-stream": "^1.0.1"
       }
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4304,12 +4304,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-      "dev": true
-    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -6154,12 +6148,6 @@
         "merge-stream": "^1.0.1"
       }
     },
-    "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
@@ -6484,14 +6472,10 @@
       }
     },
     "materialize-css": {
-      "version": "0.100.2",
-      "resolved": "https://registry.npmjs.org/materialize-css/-/materialize-css-0.100.2.tgz",
-      "integrity": "sha512-Bf4YeoJCIdk4dlpnmVX+DIOJBbqOKwfBPD+tT5bxwXNFMLk649CGbldqtnctkkfMp+fGgSAsdYu9lo1ZolZqgA==",
-      "dev": true,
-      "requires": {
-        "hammerjs": "^2.0.8",
-        "jquery": "^3.0.0 || ^2.1.4"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/materialize-css/-/materialize-css-1.0.0.tgz",
+      "integrity": "sha512-4/oecXl8y/1i8RDZvyvwAICyqwNoKU4or5uf8uoAd74k76KzZ0Llym4zhJ5lLNUskcqjO0AuMcvNyDkpz8Z6zw==",
+      "dev": true
     },
     "math-random": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "husky": "^0.14.3",
     "jest": "^23.5.0",
+    "jquery": "^3.3.1",
     "jsdom": "^11.7.0",
     "materialize-css": "^1.0.0",
     "prettier": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "husky": "^0.14.3",
     "jest": "^23.5.0",
     "jsdom": "^11.7.0",
-    "materialize-css": "^0.100.2",
+    "materialize-css": "^1.0.0",
     "prettier": "^1.11.1",
     "webpack": "^1.13.1"
   },

--- a/test/setup.js
+++ b/test/setup.js
@@ -3,7 +3,6 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 global.$ = require('jquery');
-window.Hammer = require('materialize-css/js/hammer.min.js');
 global.M = require('materialize-css');
 
 Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
Update to latest materialize-css (no jquery) and installs devDep jquery for specs until all components are migrated