### PR TITLE
It's now possible to add extended components to the navbar

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,13 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Col from './Col';
 import Icon from './Icon';
 
 class Navbar extends Component {
   constructor(props) {
     super(props);
-    this.renderSideNav = this.renderSideNav.bind(this);
   }
 
   componentDidMount() {
@@ -16,61 +14,73 @@ class Navbar extends Component {
     }
   }
 
-  renderSideNav() {
-    return (
-      <ul id="nav-mobile" className="side-nav">
-        {this.props.children}
-      </ul>
-    );
-  }
-
   render() {
     const {
       brand,
       className,
+      extendsWith,
       fixed,
-      left,
-      right,
+      alignLinks,
       centerLogo,
       href,
+      children,
       ...other
     } = this.props;
 
     delete other.options;
 
-    let classes = {
-      right: right,
-      'hide-on-med-and-down': true
-    };
-
-    let brandClasses = {
+    let brandClasses = cx({
       'brand-logo': true,
-      right: left,
-      center: centerLogo
-    };
+      center: centerLogo,
+      left: alignLinks === 'right'
+    });
 
-    let content = (
+    const navMobileCSS = cx('hide-on-med-and-down', [alignLinks]);
+
+    const links = React.Children.map((link, index) => (
+      <li key={index}>{link}</li>
+    ));
+
+    let navbar = (
       <nav {...other} className={className}>
         <div className="nav-wrapper">
-          <Col s={12}>
-            <a href={href} className={cx(brandClasses)}>
+          {brand && (
+            <a href="/" className={brandClasses}>
               {brand}
             </a>
-            <ul className={cx(className, classes)}>{this.props.children}</ul>
-            {this.renderSideNav()}
-            <a className="button-collapse" href="#" data-activates="nav-mobile">
-              <Icon>view_headline</Icon>
-            </a>
-          </Col>
+          )}
+          <a href="#!" data-target="mobile-nav" className="sidenav-trigger">
+            <Icon>menu</Icon>
+          </a>
+          <ul className={navMobileCSS}>{links}</ul>
         </div>
+        {extendsWith && (
+          <div className="nav-content">
+            {extendsWith.map((elem, index) => <div key={index}>{elem}</div>)}
+          </div>
+        )}
       </nav>
     );
 
     if (fixed) {
-      content = <div className="navbar-fixed">{content}</div>;
+      navbar = <div className="navbar-fixed">{navbar}</div>;
     }
 
-    return content;
+    return (
+      <React.Fragment>
+        {navbar}
+
+        <ul
+          id="mobile-nav"
+          className="sidenav"
+          ref={ul => {
+            this._sidenav = ul;
+          }}
+        >
+          {links}
+        </ul>
+      </React.Fragment>
+    );
   }
 }
 
@@ -78,14 +88,12 @@ Navbar.propTypes = {
   brand: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.string,
+  extendsWith: PropTypes.arrayOf(PropTypes.node),
   /**
-   * Makes the navbar links left aligned
+   * left makes the navbar links left aligned, right makes them right aligned
    */
+  alignLinks: PropTypes.oneOf(['left', 'right']),
   left: PropTypes.bool,
-  /**
-   * Makes the navbar links right aligned
-   */
-  right: PropTypes.bool,
   /**
    * The logo will center itself on medium and down screens.
    * Specifying centerLogo as a prop the logo will always be centered

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -101,7 +101,6 @@ Navbar.propTypes = {
    * left makes the navbar links left aligned, right makes them right aligned
    */
   alignLinks: PropTypes.oneOf(['left', 'right']),
-  left: PropTypes.bool,
   /**
    * The logo will center itself on medium and down screens.
    * Specifying centerLogo as a prop the logo will always be centered

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -43,6 +43,8 @@ class Navbar extends Component {
       left: alignLinks === 'right'
     });
 
+    const classes = cx({ 'nav-extended': extendWith }, className);
+
     const navMobileCSS = cx('hide-on-med-and-down', [alignLinks]);
 
     const links = React.Children.map((link, index) => (
@@ -50,7 +52,7 @@ class Navbar extends Component {
     ));
 
     let navbar = (
-      <nav {...other} className={className}>
+      <nav {...other} className={classes}>
         <div className="nav-wrapper">
           {brand && (
             <a href={href} className={brandClasses}>

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -53,7 +53,7 @@ class Navbar extends Component {
       <nav {...other} className={className}>
         <div className="nav-wrapper">
           {brand && (
-            <a href="/" className={brandClasses}>
+            <a href={href} className={brandClasses}>
               {brand}
             </a>
           )}

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -9,8 +9,16 @@ class Navbar extends Component {
   }
 
   componentDidMount() {
-    if (typeof $ !== 'undefined') {
-      $('.button-collapse').sideNav(this.props.options);
+    const { options } = this.props;
+
+    if (typeof M !== 'undefined') {
+      this.instance = M.Sidenav.init(this._sidenav, options);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.instance) {
+      this.instance.destroy();
     }
   }
 

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -26,7 +26,7 @@ class Navbar extends Component {
     const {
       brand,
       className,
-      extendsWith,
+      extendWith,
       fixed,
       alignLinks,
       centerLogo,
@@ -37,7 +37,7 @@ class Navbar extends Component {
 
     delete other.options;
 
-    let brandClasses = cx({
+    const brandClasses = cx({
       'brand-logo': true,
       center: centerLogo,
       left: alignLinks === 'right'
@@ -62,9 +62,9 @@ class Navbar extends Component {
           </a>
           <ul className={navMobileCSS}>{links}</ul>
         </div>
-        {extendsWith && (
+        {extendWith && (
           <div className="nav-content">
-            {extendsWith.map((elem, index) => <div key={index}>{elem}</div>)}
+            {extendWith.map((elem, index) => <div key={index}>{elem}</div>)}
           </div>
         )}
       </nav>
@@ -96,7 +96,7 @@ Navbar.propTypes = {
   brand: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.string,
-  extendsWith: PropTypes.arrayOf(PropTypes.node),
+  extendWith: PropTypes.arrayOf(PropTypes.node),
   /**
    * left makes the navbar links left aligned, right makes them right aligned
    */

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from './Icon';
 
+import constants from './constants';
 class Navbar extends Component {
   constructor(props) {
     super(props);
@@ -81,7 +82,7 @@ class Navbar extends Component {
         {navbar}
 
         <ul
-          id="mobile-nav"
+          id={constants.MOBILE_NAV_ID}
           className="sidenav"
           ref={ul => {
             this._sidenav = ul;

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,5 +4,6 @@ export default {
   SIZES: ['s', 'm', 'l', 'xl'],
   PLACEMENTS: ['left', 'center', 'right'],
   SCALES: ['big', 'small'],
-  ICON_SIZES: ['tiny', 'small', 'medium', 'large']
+  ICON_SIZES: ['tiny', 'small', 'medium', 'large'],
+  MOBILE_NAV_ID: 'mobile-nav'
 };

--- a/test/Navbar.spec.js
+++ b/test/Navbar.spec.js
@@ -27,7 +27,7 @@ describe('<Navbar />', () => {
   test('places brand on right if navbar is left aligned', () => {
     wrapper = shallow(<Navbar brand="logo" alignLinks="left" />);
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('a.brand-logo.right')).toBeTruthy();
+    expect(wrapper.find('a.brand-logo').hasClass('right'));
   });
 
   test('adds a brand node', () => {
@@ -41,11 +41,11 @@ describe('<Navbar />', () => {
   test('can be fixed', () => {
     wrapper = shallow(<Navbar fixed />);
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('.navbar-fixed')).toBeTruthy();
+    expect(wrapper.find('.navbar-fixed')).toHaveLength(1);
   });
 
   test('should have a sidenav component', () => {
     wrapper = shallow(<Navbar />);
-    expect(wrapper.find('.sidenav')).toBeTruthy();
+    expect(wrapper.find('.sidenav')).toHaveLength(1);
   });
 });

--- a/test/Navbar.spec.js
+++ b/test/Navbar.spec.js
@@ -15,9 +15,9 @@ describe('<Navbar />', () => {
 
   test('renders', () => {
     wrapper = shallow(
-      <Navbar brand="Logo" right>
-        <NavItem href="get-started.html">Getting started</NavItem>
-        <NavItem href="components.html">Components</NavItem>
+      <Navbar brand="Logo" alignLinks="right">
+        <a href="get-started.html">Getting started</a>
+        <a href="components.html">Components</a>
       </Navbar>
     );
 
@@ -26,9 +26,9 @@ describe('<Navbar />', () => {
   });
 
   test('places brand on right if navbar is left aligned', () => {
-    wrapper = shallow(<Navbar brand="logo" left />);
+    wrapper = shallow(<Navbar brand="logo" alignLinks="left" />);
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('a.brand-logo.right')).toHaveLength(1);
+    expect(wrapper.find('a.brand-logo.right')).toBeTruthy();
   });
 
   test('adds a brand node', () => {
@@ -42,6 +42,6 @@ describe('<Navbar />', () => {
   test('can be fixed', () => {
     wrapper = shallow(<Navbar fixed />);
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.hasClass('navbar-fixed')).toBeTruthy();
+    expect(wrapper.find('.navbar-fixed')).toBeTruthy();
   });
 });

--- a/test/Navbar.spec.js
+++ b/test/Navbar.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import Navbar from '../src/Navbar';
-import NavItem from '../src/NavItem';
 import mocker from './helper/mocker';
 
 describe('<Navbar />', () => {
@@ -43,5 +42,10 @@ describe('<Navbar />', () => {
     wrapper = shallow(<Navbar fixed />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('.navbar-fixed')).toBeTruthy();
+  });
+
+  test('should have a sidenav component', () => {
+    wrapper = shallow(<Navbar />);
+    expect(wrapper.find('.sidenav')).toBeTruthy();
   });
 });

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -16,174 +16,134 @@ exports[`<Navbar /> adds a brand node 1`] = `
     <div
       className="nav-wrapper"
     >
-      <Col
-        s={12}
+      <a
+        className="brand-logo"
+        href="/"
       >
-        <div
-          className="col s12"
+        <span
+          className="brando"
         >
-          <a
-            className="brand-logo"
-            href="/"
+          I AM BRAND
+        </span>
+      </a>
+      <a
+        className="sidenav-trigger"
+        data-target="mobile-nav"
+        href="#!"
+      >
+        <Icon>
+          <i
+            className="material-icons"
           >
-            <span
-              className="brando"
-            >
-              I AM BRAND
-            </span>
-          </a>
-          <ul
-            className="hide-on-med-and-down"
-          />
-          <ul
-            className="side-nav"
-            id="nav-mobile"
-          />
-          <a
-            className="button-collapse"
-            data-activates="nav-mobile"
-            href="#"
-          >
-            <Icon>
-              <i
-                className="material-icons"
-              >
-                view_headline
-              </i>
-            </Icon>
-          </a>
-        </div>
-      </Col>
+            menu
+          </i>
+        </Icon>
+      </a>
+      <ul
+        className="hide-on-med-and-down "
+      />
     </div>
   </nav>
+  <ul
+    className="sidenav"
+    id="mobile-nav"
+  />
 </Navbar>
 `;
 
 exports[`<Navbar /> can be fixed 1`] = `
-<div
-  className="navbar-fixed"
->
-  <nav>
-    <div
-      className="nav-wrapper"
-    >
-      <Col
-        s={12}
+<Fragment>
+  <div
+    className="navbar-fixed"
+  >
+    <nav>
+      <div
+        className="nav-wrapper"
       >
         <a
-          className="brand-logo"
-          href="/"
-        />
-        <ul
-          className="hide-on-med-and-down"
-        />
-        <ul
-          className="side-nav"
-          id="nav-mobile"
-        />
-        <a
-          className="button-collapse"
-          data-activates="nav-mobile"
-          href="#"
+          className="sidenav-trigger"
+          data-target="mobile-nav"
+          href="#!"
         >
           <Icon>
-            view_headline
+            menu
           </Icon>
         </a>
-      </Col>
-    </div>
-  </nav>
-</div>
+        <ul
+          className="hide-on-med-and-down "
+        />
+      </div>
+    </nav>
+  </div>
+  <ul
+    className="sidenav"
+    id="mobile-nav"
+  />
+</Fragment>
 `;
 
 exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
-<nav>
-  <div
-    className="nav-wrapper"
-  >
-    <Col
-      s={12}
-    >
-      <a
-        className="brand-logo right"
-        href="/"
-      >
-        logo
-      </a>
-      <ul
-        className="hide-on-med-and-down"
-      />
-      <ul
-        className="side-nav"
-        id="nav-mobile"
-      />
-      <a
-        className="button-collapse"
-        data-activates="nav-mobile"
-        href="#"
-      >
-        <Icon>
-          view_headline
-        </Icon>
-      </a>
-    </Col>
-  </div>
-</nav>
-`;
-
-exports[`<Navbar /> renders 1`] = `
-<nav>
-  <div
-    className="nav-wrapper"
-  >
-    <Col
-      s={12}
+<Fragment>
+  <nav>
+    <div
+      className="nav-wrapper"
     >
       <a
         className="brand-logo"
         href="/"
       >
-        Logo
+        logo
       </a>
-      <ul
-        className="right hide-on-med-and-down"
-      >
-        <NavItem
-          href="get-started.html"
-        >
-          Getting started
-        </NavItem>
-        <NavItem
-          href="components.html"
-        >
-          Components
-        </NavItem>
-      </ul>
-      <ul
-        className="side-nav"
-        id="nav-mobile"
-      >
-        <NavItem
-          href="get-started.html"
-        >
-          Getting started
-        </NavItem>
-        <NavItem
-          href="components.html"
-        >
-          Components
-        </NavItem>
-      </ul>
       <a
-        className="button-collapse"
-        data-activates="nav-mobile"
-        href="#"
+        className="sidenav-trigger"
+        data-target="mobile-nav"
+        href="#!"
       >
         <Icon>
-          view_headline
+          menu
         </Icon>
       </a>
-    </Col>
-  </div>
-</nav>
+      <ul
+        className="hide-on-med-and-down left"
+      />
+    </div>
+  </nav>
+  <ul
+    className="sidenav"
+    id="mobile-nav"
+  />
+</Fragment>
+`;
+
+exports[`<Navbar /> renders 1`] = `
+<Fragment>
+  <nav>
+    <div
+      className="nav-wrapper"
+    >
+      <a
+        className="brand-logo left"
+        href="/"
+      >
+        Logo
+      </a>
+      <a
+        className="sidenav-trigger"
+        data-target="mobile-nav"
+        href="#!"
+      >
+        <Icon>
+          menu
+        </Icon>
+      </a>
+      <ul
+        className="hide-on-med-and-down right"
+      />
+    </div>
+  </nav>
+  <ul
+    className="sidenav"
+    id="mobile-nav"
+  />
+</Fragment>
 `;

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -12,7 +12,9 @@ exports[`<Navbar /> adds a brand node 1`] = `
   href="/"
   options={Object {}}
 >
-  <nav>
+  <nav
+    className=""
+  >
     <div
       className="nav-wrapper"
     >
@@ -56,7 +58,9 @@ exports[`<Navbar /> can be fixed 1`] = `
   <div
     className="navbar-fixed"
   >
-    <nav>
+    <nav
+      className=""
+    >
       <div
         className="nav-wrapper"
       >
@@ -84,7 +88,9 @@ exports[`<Navbar /> can be fixed 1`] = `
 
 exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
 <Fragment>
-  <nav>
+  <nav
+    className=""
+  >
     <div
       className="nav-wrapper"
     >
@@ -117,7 +123,9 @@ exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
 
 exports[`<Navbar /> renders 1`] = `
 <Fragment>
-  <nav>
+  <nav
+    className=""
+  >
     <div
       className="nav-wrapper"
     >


### PR DESCRIPTION
# Description

It's now possible to add extended components to the `NavBar`[ as per the doc](https://materializecss.com/navbar.html#navbar-tabs).
Also dropping _jQuery_ initialization and the use of `NavItem` component.
This was necessary to really make use of `React Router` `Link` component or any other custom component one may wish to use to fulfill routing purposes.

I think this approach is more flexible and resolve some edges cases, as in #650  

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Used it in a project of mine and tested running `npm test`.
I've updated the snapshot accordingly to the changes.

Also added a new test to check if the mobile sidenav is rendered.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)