### PR TITLE
3.0.0-Badge

### DIFF
--- a/src/Badge.js
+++ b/src/Badge.js
@@ -2,14 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-const Badge = ({ className, newIcon, children, ...props }) => {
+const Badge = ({ className, newIcon, caption, children, ...props }) => {
   let classes = {
     badge: true,
     new: newIcon
   };
 
   return (
-    <span {...props} className={cx(classes, className)}>
+    <span
+      {...props}
+      data-badge-caption={caption}
+      className={cx(classes, className)}
+    >
       {children}
     </span>
   );
@@ -21,7 +25,11 @@ Badge.propTypes = {
   /**
    * Add the <b>new</b> class name
    */
-  newIcon: PropTypes.bool
+  newIcon: PropTypes.bool,
+  /**
+   * One can explicitly set the caption in a badge using the caption prop
+   */
+  caption: PropTypes.string
 };
 
 export default Badge;

--- a/test/Badge.spec.js
+++ b/test/Badge.spec.js
@@ -19,4 +19,9 @@ describe('<Badge />', () => {
     wrapper = shallow(<Badge newIcon>3</Badge>);
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('should output a custom caption if provided', () => {
+    wrapper = shallow(<Badge caption="custom caption">4</Badge>);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/test/__snapshots__/Badge.spec.js.snap
+++ b/test/__snapshots__/Badge.spec.js.snap
@@ -23,3 +23,12 @@ exports[`<Badge /> should output a badge with the className of \`badge\` 1`] = `
   4
 </span>
 `;
+
+exports[`<Badge /> should output a custom caption if provided 1`] = `
+<span
+  className="badge"
+  data-badge-caption="custom caption"
+>
+  4
+</span>
+`;


### PR DESCRIPTION
# Description

This Pull Request is for #581.

It's now possible to explicitly set the caption in a `Badge`.

Other than that, this component is good as it is as far as `materialize-css` version 1.0.0 is considered.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added a new test to check if the custom caption is correctly rendered.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
