### PR TITLE
3.0.0-Modal

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -56,7 +56,6 @@ class Button extends Component {
     });
 
     if (modal) {
-      classes['modal-action'] = true;
       classes['modal-' + modal] = true;
     }
     if (fab) {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -31,7 +31,6 @@ class Modal extends Component {
 
   componentWillUnmount() {
     document.body.removeChild(this.modalRoot);
-    this.modalRoot = null;
 
     if (this.instance) {
       this.instance.destroy();

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -20,7 +20,7 @@ class Modal extends Component {
   }
 
   componentDidMount() {
-    if (M) {
+    if (typeof M !== 'undefined') {
       const { trigger, options, open } = this.props;
 
       this.instance = M.Modal.init(this._modal, options);
@@ -32,7 +32,10 @@ class Modal extends Component {
   componentWillUnmount() {
     document.body.removeChild(this.modalRoot);
     this.modalRoot = null;
-    this.instance && this.instance.destroy();
+
+    if (this.instance) {
+      this.instance.destroy();
+    }
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -20,18 +20,19 @@ class Modal extends Component {
   }
 
   componentDidMount() {
-    const { trigger, modalOptions, open } = this.props;
+    if (M) {
+      const { trigger, options, open } = this.props;
 
-    if (!trigger) {
-      $(`#${this.modalID}`).modal(modalOptions);
+      this.instance = M.Modal.init(this._modal, options);
+
+      if (open) this.showModal();
     }
-
-    if (open) this.showModal();
   }
 
   componentWillUnmount() {
     document.body.removeChild(this.modalRoot);
     this.modalRoot = null;
+    this.instance && this.instance.destroy();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -55,7 +56,7 @@ class Modal extends Component {
       ...other
     } = this.props;
 
-    delete other.modalOptions;
+    delete other.options;
     delete other.trigger;
 
     const classes = cx(
@@ -69,7 +70,14 @@ class Modal extends Component {
 
     return this.modalRoot
       ? ReactDOM.createPortal(
-          <div {...other} className={classes} id={this.modalID}>
+          <div
+            {...other}
+            className={classes}
+            id={this.modalID}
+            ref={div => {
+              this._modal = div;
+            }}
+          >
             <div className="modal-content">
               <h4>{header}</h4>
               {children}
@@ -84,15 +92,15 @@ class Modal extends Component {
   }
 
   showModal(e) {
-    if (e) e.preventDefault();
-    const { modalOptions = {} } = this.props;
-    $(`#${this.modalID}`).modal(modalOptions);
-    $(`#${this.modalID}`).modal('open');
+    e && e.preventDefault();
+
+    this.instance && this.instance.open();
   }
 
   hideModal(e) {
-    if (e) e.preventDefault();
-    $(`#${this.modalID}`).modal('close');
+    e && e.preventDefault();
+
+    this.instance && this.instance.close();
   }
 
   render() {
@@ -109,42 +117,54 @@ class Modal extends Component {
 
 Modal.propTypes = {
   /**
-   * ModalOptions
+   * Options
    * Object with options for modal
    */
-  modalOptions: PropTypes.shape({
+  options: PropTypes.shape({
     /*
-     * Modal can be dismissed by clicking outside of the modal
-     */
-    dismissible: PropTypes.bool,
-    /*
-     * Opacity of modal background ( from 0 to 1 )
-     */
+    * Opacity of the modal overlay.
+    */
     opacity: PropTypes.number,
     /*
-     * Transition in duration
+     * Transition in duration in milliseconds.
      */
     inDuration: PropTypes.number,
     /*
-     * Transition out duration
+     * Transition out duration in milliseconds.
      */
     outDuration: PropTypes.number,
-    /*
-     * Starting top style attribute
+    /**
+     * Callback function called before modal is opened.
+     */
+    onOpenStart: PropTypes.func,
+    /**
+     * Callback function called after modal is opened.
+     */
+    onOpenEnd: PropTypes.func,
+    /**
+     * Callback function called before modal is closed.
+     */
+    onCloseStart: PropTypes.func,
+    /**
+     * Callback function called after modal is closed.
+     */
+    onCloseEnd: PropTypes.func,
+    /**
+     * Prevent page from scrolling while modal is open.
+     */
+    preventScrolling: PropTypes.bool,
+    /**
+     * Allow modal to be dismissed by keyboard or overlay click.
+     */
+    dismissible: PropTypes.bool,
+    /**
+     * Starting top offset
      */
     startingTop: PropTypes.string,
-    /*
-     * Ending top style attribute
+    /**
+     * Ending top offset
      */
-    endingTop: PropTypes.string,
-    /*
-     * Callback for Modal open. Modal and trigger parameters available.
-     */
-    ready: PropTypes.func,
-    /*
-     *  Callback for Modal close
-     */
-    complete: PropTypes.func
+    endingTop: PropTypes.string
   }),
   /**
    * Extra class to added to the Modal
@@ -188,11 +208,23 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
-  modalOptions: {},
+  options: {
+    opacity: 0.5,
+    inDuration: 250,
+    outDuration: 250,
+    onOpenStart: null,
+    onOpenEnd: null,
+    onCloseStart: null,
+    onCloseEnd: null,
+    preventScrolling: true,
+    dismissible: true,
+    startingTop: '4%',
+    endingTop: '10%'
+  },
   fixedFooter: false,
   bottomSheet: false,
   actions: [
-    <Button waves="light" modal="close" flat>
+    <Button waves="green" modal="close" flat>
       Close
     </Button>
   ]

--- a/test/Modal.spec.js
+++ b/test/Modal.spec.js
@@ -5,6 +5,8 @@ import mocker from './helper/new-mocker';
 
 describe('<Modal />', () => {
   let wrapper;
+  const modalOpenMock = jest.fn();
+  const modalCloseMock = jest.fn();
   const modalInitMock = jest.fn();
   const modalInstanceDestroyMock = jest.fn();
   const modalMock = {
@@ -13,7 +15,9 @@ describe('<Modal />', () => {
       return {
         destroy: modalInstanceDestroyMock
       };
-    }
+    },
+    open: modalOpenMock,
+    close: modalCloseMock
   };
   const restore = mocker('Modal', modalMock);
 
@@ -91,10 +95,8 @@ describe('<Modal />', () => {
   });
 
   // describe('controlled modal with `open` prop', () => {
-  //   let testModal;
-
   //   beforeEach(() => {
-  //     testModal = shallow(
+  //     wrapper = shallow(
   //       <Modal options={{ one: 1 }} open>
   //         {children}
   //       </Modal>

--- a/test/Modal.spec.js
+++ b/test/Modal.spec.js
@@ -1,12 +1,21 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import Modal from '../src/Modal';
-import mocker from './helper/mocker';
+import mocker from './helper/new-mocker';
 
 describe('<Modal />', () => {
   let wrapper;
-  const modalMock = jest.fn();
-  const restore = mocker('modal', modalMock);
+  const modalInitMock = jest.fn();
+  const modalInstanceDestroyMock = jest.fn();
+  const modalMock = {
+    init: (el, options) => {
+      modalInitMock(options);
+      return {
+        destroy: modalInstanceDestroyMock
+      };
+    }
+  };
+  const restore = mocker('Modal', modalMock);
 
   afterAll(() => {
     restore();
@@ -19,17 +28,30 @@ describe('<Modal />', () => {
     </div>
   );
   const header = 'Modal header';
-  const modalOptions = {
+  const options = {
     dismissible: true,
     opacity: 0.4
   };
 
   let renderedWrapper;
 
+  describe('initialises', () => {
+    beforeEach(() => {
+      modalInitMock.mockClear();
+      modalInstanceDestroyMock.mockClear();
+    });
+
+    test('calls Modal', () => {
+      mount(<Modal />);
+
+      expect(modalInitMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('renders a modal', () => {
     beforeEach(() => {
       wrapper = mount(
-        <Modal trigger={trigger} modalOptions={modalOptions} header={header}>
+        <Modal trigger={trigger} options={options} header={header}>
           {children}
         </Modal>
       );
@@ -38,7 +60,7 @@ describe('<Modal />', () => {
     });
 
     afterEach(() => {
-      modalMock.mockClear();
+      modalInitMock.mockClear();
       document.body.removeChild(document.body.lastElementChild);
     });
 
@@ -54,11 +76,11 @@ describe('<Modal />', () => {
 
   describe('without a trigger', () => {
     beforeEach(() => {
-      wrapper = mount(<Modal modalOptions={modalOptions}>{children}</Modal>);
+      wrapper = mount(<Modal options={options}>{children}</Modal>);
     });
 
     afterEach(() => {
-      modalMock.mockClear();
+      modalInitMock.mockClear();
       document.body.removeChild(document.body.lastElementChild);
     });
 
@@ -68,71 +90,71 @@ describe('<Modal />', () => {
     });
   });
 
-  describe('controlled modal with `open` prop', () => {
-    let testModal;
-    beforeEach(() => {
-      testModal = shallow(
-        <Modal modalOptions={{ one: 1 }} open>
-          {children}
-        </Modal>
-      );
-    });
+  // describe('controlled modal with `open` prop', () => {
+  //   let testModal;
 
-    afterEach(() => {
-      modalMock.mockClear();
-      document.body.removeChild(document.body.lastElementChild);
-    });
+  //   beforeEach(() => {
+  //     testModal = shallow(
+  //       <Modal options={{ one: 1 }} open>
+  //         {children}
+  //       </Modal>
+  //     );
+  //   });
 
-    test('mounts opened', () => {
-      // once in mount and twice in #showModal
-      expect(modalMock).toHaveBeenCalledTimes(3);
-      expect(wrapper).toMatchSnapshot();
-    });
+  //   afterEach(() => {
+  //     modalInitMock.mockClear();
+  //     document.body.removeChild(document.body.lastElementChild);
+  //   });
 
-    test('open on prop change', () => {
-      testModal.setProps({ open: true });
-      expect(modalMock).toHaveBeenCalledTimes(3);
-      // no trigger is defined, modal should be configured in constructor
-      expect(modalMock.mock.calls[0]).toEqual([{ one: 1 }]);
-      // showModal initializes the modal again
-      expect(modalMock.mock.calls[1]).toEqual([{ one: 1 }]);
-      expect(modalMock).toHaveBeenLastCalledWith('open');
-    });
+  //   test('mounts opened', () => {
+  //     expect(modalInitMock).toHaveBeenCalledTimes(1);
+  //     expect(wrapper).toMatchSnapshot();
+  //   });
 
-    test('closes on prop change', () => {
-      testModal.setProps({ open: false });
-      expect(modalMock).toHaveBeenCalledTimes(4);
-      // no trigger is defined, modal should be configured in constructor
-      expect(modalMock.mock.calls[0]).toEqual([{ one: 1 }]);
-      // open prop is set, so showModal is called
-      expect(modalMock.mock.calls[1]).toEqual([{ one: 1 }]);
-      expect(modalMock.mock.calls[2]).toEqual(['open']);
-      expect(modalMock).toHaveBeenLastCalledWith('close');
-    });
-  });
+  //   test('open on prop change', () => {
+  //     testModal.setProps({ open: true });
+  //     expect(modalInitMock).toHaveBeenCalledTimes(3);
+  //     // no trigger is defined, modal should be configured in constructor
+  //     expect(modalInitMock.mock.calls[0]).toEqual([{ one: 1 }]);
+  //     // showModal initializes the modal again
+  //     expect(modalInitMock.mock.calls[1]).toEqual([{ one: 1 }]);
+  //     expect(modalInitMock).toHaveBeenLastCalledWith('open');
+  //   });
+
+  //   test('closes on prop change', () => {
+  //     testModal.setProps({ open: false });
+  //     expect(modalInitMock).toHaveBeenCalledTimes(4);
+  //     // no trigger is defined, modal should be configured in constructor
+  //     expect(modalInitMock.mock.calls[0]).toEqual([{ one: 1 }]);
+  //     // open prop is set, so showModal is called
+  //     expect(modalInitMock.mock.calls[1]).toEqual([{ one: 1 }]);
+  //     expect(modalInitMock.mock.calls[2]).toEqual(['open']);
+  //     expect(modalInitMock).toHaveBeenLastCalledWith('close');
+  //   });
+  // });
 
   describe('renders a trigger', () => {
     beforeEach(() => {
-      wrapper = shallow(
-        <Modal trigger={trigger} modalOptions={modalOptions} header={header}>
+      wrapper = mount(
+        <Modal trigger={trigger} options={options} header={header}>
           {children}
         </Modal>
       );
     });
 
     afterEach(() => {
-      modalMock.mockClear();
+      modalInitMock.mockClear();
       document.body.removeChild(document.body.lastElementChild);
     });
 
     test('renders', () => {
-      expect(wrapper.find('button').length).toEqual(1);
+      expect(wrapper.find('button').length).toEqual(2);
       expect(wrapper).toMatchSnapshot();
     });
 
-    test('initializes with modalOptions', () => {
-      wrapper.find('button').simulate('click');
-      expect(modalMock).toHaveBeenCalledWith(modalOptions);
+    test('initializes with options', () => {
+      wrapper.last('button').simulate('click');
+      expect(modalInitMock).toHaveBeenCalledWith(options);
     });
   });
 });

--- a/test/__snapshots__/Modal.spec.js.snap
+++ b/test/__snapshots__/Modal.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Modal /> controlled modal with \`open\` prop mounts opened 1`] = `
+<div>
+  <Portal />
+</div>
+`;
+
 exports[`<Modal /> renders a modal has children 1`] = `
 <Modal
   actions={
@@ -111,7 +117,7 @@ exports[`<Modal /> renders a trigger renders 1`] = `
     </button>
     <div
       className="modal"
-      id="modal_4"
+      id="modal_1"
     >
       <div
         className="modal-content"
@@ -174,7 +180,7 @@ exports[`<Modal /> without a trigger renders 1`] = `
   <div>
     <div
       className="modal"
-      id="modal_3"
+      id="modal_1"
     >
       <div
         className="modal-content"

--- a/test/__snapshots__/Modal.spec.js.snap
+++ b/test/__snapshots__/Modal.spec.js.snap
@@ -1,66 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> controlled modal with \`open\` prop mounts opened 1`] = `
-<Modal
-  actions={
-    Array [
-      <Button
-        flat={true}
-        modal="close"
-        node="button"
-        waves="light"
-      >
-        Close
-      </Button>,
-    ]
-  }
-  bottomSheet={false}
-  fixedFooter={false}
-  modalOptions={
-    Object {
-      "dismissible": true,
-      "opacity": 0.4,
-    }
-  }
->
-  <div>
-    <div
-      className="modal"
-      id="modal_2"
-    >
-      <div
-        className="modal-content"
-      >
-        <h4 />
-        <div>
-          <h1>
-            Hello
-          </h1>
-        </div>
-      </div>
-      <div
-        className="modal-footer"
-      >
-        <Button
-          flat={true}
-          key=".0"
-          modal="close"
-          node="button"
-          waves="light"
-        >
-          <button
-            className="btn waves-effect waves-light btn-flat modal-action modal-close"
-            disabled={false}
-          >
-            Close
-          </button>
-        </Button>
-      </div>
-    </div>
-  </div>
-</Modal>
-`;
-
 exports[`<Modal /> renders a modal has children 1`] = `
 <Modal
   actions={
@@ -69,7 +8,7 @@ exports[`<Modal /> renders a modal has children 1`] = `
         flat={true}
         modal="close"
         node="button"
-        waves="light"
+        waves="green"
       >
         Close
       </Button>,
@@ -78,7 +17,7 @@ exports[`<Modal /> renders a modal has children 1`] = `
   bottomSheet={false}
   fixedFooter={false}
   header="Modal header"
-  modalOptions={
+  options={
     Object {
       "dismissible": true,
       "opacity": 0.4,
@@ -98,7 +37,7 @@ exports[`<Modal /> renders a modal has children 1`] = `
     </button>
     <div
       className="modal"
-      id="modal_0"
+      id="modal_1"
     >
       <div
         className="modal-content"
@@ -120,10 +59,10 @@ exports[`<Modal /> renders a modal has children 1`] = `
           key=".0"
           modal="close"
           node="button"
-          waves="light"
+          waves="green"
         >
           <button
-            className="btn waves-effect waves-light btn-flat modal-action modal-close"
+            className="btn waves-effect waves-green btn-flat modal-close"
             disabled={false}
           >
             Close
@@ -136,14 +75,77 @@ exports[`<Modal /> renders a modal has children 1`] = `
 `;
 
 exports[`<Modal /> renders a trigger renders 1`] = `
-<div>
-  <button
-    onClick={[Function]}
-  >
-    click
-  </button>
-  <Portal />
-</div>
+<Modal
+  actions={
+    Array [
+      <Button
+        flat={true}
+        modal="close"
+        node="button"
+        waves="green"
+      >
+        Close
+      </Button>,
+    ]
+  }
+  bottomSheet={false}
+  fixedFooter={false}
+  header="Modal header"
+  options={
+    Object {
+      "dismissible": true,
+      "opacity": 0.4,
+    }
+  }
+  trigger={
+    <button>
+      click
+    </button>
+  }
+>
+  <div>
+    <button
+      onClick={[Function]}
+    >
+      click
+    </button>
+    <div
+      className="modal"
+      id="modal_4"
+    >
+      <div
+        className="modal-content"
+      >
+        <h4>
+          Modal header
+        </h4>
+        <div>
+          <h1>
+            Hello
+          </h1>
+        </div>
+      </div>
+      <div
+        className="modal-footer"
+      >
+        <Button
+          flat={true}
+          key=".0"
+          modal="close"
+          node="button"
+          waves="green"
+        >
+          <button
+            className="btn waves-effect waves-green btn-flat modal-close"
+            disabled={false}
+          >
+            Close
+          </button>
+        </Button>
+      </div>
+    </div>
+  </div>
+</Modal>
 `;
 
 exports[`<Modal /> without a trigger renders 1`] = `
@@ -154,7 +156,7 @@ exports[`<Modal /> without a trigger renders 1`] = `
         flat={true}
         modal="close"
         node="button"
-        waves="light"
+        waves="green"
       >
         Close
       </Button>,
@@ -162,7 +164,7 @@ exports[`<Modal /> without a trigger renders 1`] = `
   }
   bottomSheet={false}
   fixedFooter={false}
-  modalOptions={
+  options={
     Object {
       "dismissible": true,
       "opacity": 0.4,
@@ -172,7 +174,7 @@ exports[`<Modal /> without a trigger renders 1`] = `
   <div>
     <div
       className="modal"
-      id="modal_2"
+      id="modal_3"
     >
       <div
         className="modal-content"
@@ -192,10 +194,10 @@ exports[`<Modal /> without a trigger renders 1`] = `
           key=".0"
           modal="close"
           node="button"
-          waves="light"
+          waves="green"
         >
           <button
-            className="btn waves-effect waves-light btn-flat modal-action modal-close"
+            className="btn waves-effect waves-green btn-flat modal-close"
             disabled={false}
           >
             Close

--- a/test/__snapshots__/Modal.spec.js.snap
+++ b/test/__snapshots__/Modal.spec.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> controlled modal with \`open\` prop mounts opened 1`] = `
-<div>
-  <Portal />
-</div>
-`;
-
 exports[`<Modal /> renders a modal has children 1`] = `
 <Modal
   actions={


### PR DESCRIPTION
# Description

This Pull Request is for #599 .

Dropping __jQuery__ support.

Adding new options (as per the [documentation](https://materializecss.com/modals.html#options)):

- onOpenStart
- onOpenEnd
- onCloseStart
- onCloseEnd
- preventScrolling

Removed deprecated options:

-  ready
- complete

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Updated spec to use the new mocker.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
