### PR TITLE
3.0.0-SearchForm

### DIFF
--- a/src/SearchForm.js
+++ b/src/SearchForm.js
@@ -5,7 +5,7 @@ const SearchForm = () => (
   <form>
     <div className="input-field">
       <input id="search" type="search" required />
-      <label htmlFor="search">
+      <label className="label-icon" htmlFor="search">
         <Icon>search</Icon>
       </label>
       <Icon>close</Icon>

--- a/test/__snapshots__/SearchForm.spec.js.snap
+++ b/test/__snapshots__/SearchForm.spec.js.snap
@@ -11,6 +11,7 @@ exports[`<SearchForm /> should render 1`] = `
       type="search"
     />
     <label
+      className="label-icon"
       htmlFor="search"
     >
       <Icon>


### PR DESCRIPTION
# Description

This Pull Request is for #604 

Adding missing CSS Class `label-icon` to label element.

Apart from this bug fix no other changes occurred from version __0.100.2__ and __1.0.0__ of `materialize-css`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated snapshot accordingly to the bug fix.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
