### PR TITLE
3.0.0-CollectionItem

### DIFF
--- a/src/CollectionItem.js
+++ b/src/CollectionItem.js
@@ -1,31 +1,39 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-class CollectionItem extends Component {
-  render() {
-    const { active, children, className, ...other } = this.props;
+const CollectionItem = props => {
+  const { active, children, className, avatar, ...other } = props;
 
-    const classes = {
-      'collection-item': true,
-      active: active
-    };
+  const classes = cx(
+    'collection-item',
+    {
+      active,
+      avatar
+    },
+    className
+  );
 
-    let C = this.props.href ? 'a' : 'li';
+  let C = props.href ? 'a' : 'li';
 
-    return (
-      <C {...other} className={cx(className, classes)}>
-        {children}
-      </C>
-    );
-  }
-}
+  return (
+    <C {...other} className={classes}>
+      {children}
+    </C>
+  );
+};
 
 CollectionItem.propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
-  href: PropTypes.string
+  href: PropTypes.string,
+  avatar: PropTypes.bool
+};
+
+CollectionItem.defaultProps = {
+  active: false,
+  avatar: false
 };
 
 export default CollectionItem;

--- a/src/CollectionItem.js
+++ b/src/CollectionItem.js
@@ -2,46 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-const CollectionItem = props => {
-  const { active, children, className, avatar, ...other } = props;
-
-  const classes = cx(
-    'collection-item',
-    {
-      active,
-      avatar
-    },
-    className
-  );
-
-  let C = props.href ? 'a' : 'li';
-
-  return (
-    <C {...other} className={classes}>
+const CollectionItem = ({ children, className, href, ...other }) => {
+  let item = (
+    <li {...other} className={cx('collection-item', className)}>
       {children}
-    </C>
+    </li>
   );
+
+  if (href) {
+    item = (
+      <a {...other} href={href} className={cx('collection-item', className)}>
+        {children}
+      </a>
+    );
+  }
+
+  return item;
 };
 
 CollectionItem.propTypes = {
-  active: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
   /* 
    * Default: false
    * For more information refer to : https://materializecss.com/collections.html#links 
    */
-  href: PropTypes.string,
-  /* 
-   * Default: false
-   * For more information refer to : https://materializecss.com/collections.html#circle 
-   */
-  avatar: PropTypes.bool
-};
-
-CollectionItem.defaultProps = {
-  active: false,
-  avatar: false
+  href: PropTypes.string
 };
 
 export default CollectionItem;

--- a/src/CollectionItem.js
+++ b/src/CollectionItem.js
@@ -27,7 +27,15 @@ CollectionItem.propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
+  /* 
+   * Default: false
+   * For more information refer to : https://materializecss.com/collections.html#links 
+   */
   href: PropTypes.string,
+  /* 
+   * Default: false
+   * For more information refer to : https://materializecss.com/collections.html#circle 
+   */
   avatar: PropTypes.bool
 };
 

--- a/test/CollectionItem.spec.js
+++ b/test/CollectionItem.spec.js
@@ -28,7 +28,9 @@ describe('<CollectionItem />', () => {
   });
 
   test('can have an active state', () => {
-    wrapper = shallow(<CollectionItem active>Alvin</CollectionItem>);
+    wrapper = shallow(
+      <CollectionItem className="active">Alvin</CollectionItem>
+    );
     expect(wrapper.find('.collection-item.active')).toHaveLength(1);
   });
 });

--- a/test/__snapshots__/Collection.spec.js.snap
+++ b/test/__snapshots__/Collection.spec.js.snap
@@ -11,10 +11,7 @@ exports[`<Collection /> renders 1`] = `
       names
     </h4>
   </li>
-  <CollectionItem
-    active={false}
-    avatar={false}
-  >
+  <CollectionItem>
     Alvin
   </CollectionItem>
 </ul>

--- a/test/__snapshots__/Collection.spec.js.snap
+++ b/test/__snapshots__/Collection.spec.js.snap
@@ -11,7 +11,10 @@ exports[`<Collection /> renders 1`] = `
       names
     </h4>
   </li>
-  <CollectionItem>
+  <CollectionItem
+    active={false}
+    avatar={false}
+  >
     Alvin
   </CollectionItem>
 </ul>


### PR DESCRIPTION
# Description

This Pull Request is for #591.

Nothing has changed between version __0.100.2__ and __1.0.0__ of `materialize-css`, but I took the opportunity to refactor the component into a stateless one and added a convenient `avatar` prop to `CollectionItem`.

## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x]  I have not generated a new package version. (the maintainers will handle that)
