### PR TITLE
Updating state with checked nextProps when type is checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.5.7
+
+- Fixes input#checkbox bug (Marzon #680)
+
 ### 2.5.6
 
 - Fixes multiple input bug (trishtzy #658)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "files": [

--- a/src/Input.js
+++ b/src/Input.js
@@ -41,13 +41,13 @@ class Input extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-	if (
-		nextProps.type === 'checkbox' && 
-		this.state.checked !== nextProps.checked) {
-			this.setState(
-			{
-				 checked: nextProps.checked
-			});
+	if (nextProps.type === 'checkbox' && 
+        this.state.checked !== nextProps.checked)
+        {
+            this.setState(
+            {
+                checked: nextProps.checked
+            });
     }
     if (this.isMaterialSelect() && !this.props.multiple) {
       this.setState(

--- a/src/Input.js
+++ b/src/Input.js
@@ -41,13 +41,13 @@ class Input extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-	if (nextProps.type === 'checkbox' && 
-        this.state.checked !== nextProps.checked)
-        {
-            this.setState(
-            {
-                checked: nextProps.checked
-            });
+    if (
+      nextProps.type === 'checkbox' &&
+      this.state.checked !== nextProps.checked
+    ) {
+      this.setState({
+        checked: nextProps.checked
+      });
     }
     if (this.isMaterialSelect() && !this.props.multiple) {
       this.setState(

--- a/src/Input.js
+++ b/src/Input.js
@@ -41,8 +41,13 @@ class Input extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-	if (nextProps.type === 'checkbox' && this.state.checked !== nextProps.checked) {
-         this.setState({checked: nextProps.checked});
+	if (
+		nextProps.type === 'checkbox' && 
+		this.state.checked !== nextProps.checked) {
+			this.setState(
+			{
+				 checked: nextProps.checked
+			});
     }
     if (this.isMaterialSelect() && !this.props.multiple) {
       this.setState(

--- a/src/Input.js
+++ b/src/Input.js
@@ -41,6 +41,9 @@ class Input extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+	if (nextProps.type === 'checkbox' && this.state.checked !== nextProps.checked) {
+         this.setState({checked: nextProps.checked});
+    }
     if (this.isMaterialSelect() && !this.props.multiple) {
       this.setState(
         {


### PR DESCRIPTION
# Description

There is a bug when the checked state of a Input type checkbox is changed by a external button. The Input component stills with checked false because the internal state is not changing.

Issue #525 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

