### PR TITLE
Add arrow support

### DIFF
--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -39,10 +39,8 @@ class Autocomplete extends Component {
       return null;
     }
 
-    let matches = Object.keys(data).filter(key => {
-      const index = key.toUpperCase().indexOf(value.toUpperCase());
-      return index !== -1 && value.length < key.length;
-    });
+    let matches = this._findRealValue(value);
+
     if (limit) matches = matches.slice(0, limit);
     if (matches.length === 0) {
       return null;
@@ -129,16 +127,25 @@ class Autocomplete extends Component {
       this.setState({ value: '' });
     }
 
+    // if event is enter
     if (evt.keyCode === 13) {
       evt.preventDefault();
+      // liValue is gets text content of item that pressed enter.
+      // we can't do innerHTML or innerText because there is <span className="highlight"></span>
       const liValue = matches[activeItem].textContent;
-      let value = Object.keys(this.props.data).filter(key => {
-        const index = key.toUpperCase().indexOf(liValue.toUpperCase());
-        return index !== -1 && liValue.length <= key.length;
-      });
-
+      const value = this._findRealValue(liValue);
       this._onAutocomplete(value);
     }
+  }
+
+  _findRealValue(liValue) {
+    const { data } = this.props;
+
+    // go and look to data. if you find a key that have same name with value, return it.
+    return Object.keys(data).filter(key => {
+      const index = key.toUpperCase().indexOf(liValue.toUpperCase());
+      return index !== -1 && liValue.length <= key.length;
+    });
   }
 
   _onAutocomplete(value, evt) {

--- a/test/__snapshots__/Autocomplete.spec.js.snap
+++ b/test/__snapshots__/Autocomplete.spec.js.snap
@@ -8,6 +8,7 @@ exports[`<Autocomplete /> renders 1`] = `
     className="autocomplete"
     id="testAutocompleteId"
     onChange={[Function]}
+    onKeyDown={[Function]}
     type="text"
     value=""
   />


### PR DESCRIPTION
# Description

Added arrow navigation and change with enter to Autocomplete. This PR is related with #642. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tried <Autocomplete /> with this object: `data: {
      Apple: null,
      Aot: null,
      Aoto: null,
      Microsoft: null,
      Google: 'https://placehold.it/250x250',
      Ap: null
    };`

When you press arrow down or arrow up, code is adding "active" class to li. When you press "ESC" key, value's state clears itself and "autocomplete dropdown" is closing. When you press enter, code searching value in "data" object and when find it; calling this._onAutocomplete function.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
