### PR TITLE
Add the possibility to pass other props to Container

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -2,8 +2,10 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
-const Container = props => (
-  <div className={cx('container', props.className)}>{props.children}</div>
+const Container = ({ className, children, ...props }) => (
+  <div className={cx('container', className)} {...props}>
+    {children}
+  </div>
 );
 
 Container.propTypes = {


### PR DESCRIPTION
# Description

Closing #697

During development on a side project I realized that it was impossible to pass down to this component props as `id` or `style`.

Hence, this PR.

You can now use whatever props you wish.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the component in a side project;
Runnig `yarn test`;

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
