### PR TITLE
Remove unused propTypes

### DIFF
--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -47,7 +47,7 @@ CollapsibleItem.propTypes = {
    * The node type of the header
    * @default a
    */
-  node: PropTypes.node,
+  node: PropTypes.node
 };
 
 CollapsibleItem.defaultProps = {

--- a/src/CollapsibleItem.js
+++ b/src/CollapsibleItem.js
@@ -48,10 +48,6 @@ CollapsibleItem.propTypes = {
    * @default a
    */
   node: PropTypes.node,
-  /**
-   * The scroll behavior for scrollIntoView
-   */
-  scroll: PropTypes.oneOf(['auto', 'instant', 'smooth'])
 };
 
 CollapsibleItem.defaultProps = {


### PR DESCRIPTION
Remove unused `scroll` propType introduced with [this PR](https://github.com/react-materialize/react-materialize/commit/4c89519af0ff207f0c77c3836ea6b89a2d40f18d)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
