### PR TITLE
3.0.0-beta.0-Button-Fab-Styles

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -89,8 +89,10 @@ class Button extends Component {
   }
 
   renderFab(className) {
+    const { fab, floating, large, ...other } = this.props;
     return (
       <div
+        {...other}
         ref={el => (this._floatingActionBtn = el)}
         className={cx('fixed-action-btn')}
       >

--- a/src/Button.js
+++ b/src/Button.js
@@ -88,15 +88,15 @@ class Button extends Component {
     }
   }
 
-  renderFab(className) {
-    const { fab, floating, large, ...other } = this.props;
+  renderFab(classes) {
+    const { fab, floating, large, className, ...other } = this.props;
     return (
       <div
         {...other}
         ref={el => (this._floatingActionBtn = el)}
         className={cx('fixed-action-btn')}
       >
-        <a className={className}>{this.renderIcon()}</a>
+        <a className={classes}>{this.renderIcon()}</a>
         <ul>
           {React.Children.map(this.props.children, child => {
             return <li key={idgen()}>{child}</li>;

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -171,7 +171,7 @@ describe('Button', () => {
     test('renders FloatingActionButton with passed styles', () => {
       const style = { bottom: '45px', right: '24px' };
       wrapper = shallow(FabButton(true, style));
-      expect(Object.keys(wrapper.props().style).length).toBeGreaterThan(0)
+      expect(Object.keys(wrapper.props().style).length).toBeGreaterThan(0);
     });
   });
 });

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -170,9 +170,8 @@ describe('Button', () => {
     });
     test('renders FloatingActionButton with passed styles', () => {
       const style = { bottom: '45px', right: '24px' };
-      wrapper = mount(FabButton(true, style));
-      expect(wrapper.props().style.bottom).toEqual(style.bottom);
-      expect(wrapper.props().style.right).toEqual(style.right);
+      wrapper = shallow(FabButton(true, style));
+      expect(Object.keys(wrapper.props().style).length).toBeGreaterThan(0)
     });
   });
 });

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -138,17 +138,8 @@ describe('Button', () => {
       toolbarEnabled: true
     };
     let wrapper;
-    const FabButton = (fabOptions = true) => (
-      <Button
-        floating
-        fab={fabOptions}
-        className="red"
-        large
-        style={{
-          bottom: '45px',
-          right: '24px'
-        }}
-      >
+    const FabButton = (fabOptions = true, style = {}) => (
+      <Button floating fab={fabOptions} className="red" large style={style}>
         <Button floating icon="insert_chart" className="red" />
         <Button floating icon="format_quote" className="yellow darken-1" />
         <Button floating icon="publish" className="green" />
@@ -176,6 +167,12 @@ describe('Button', () => {
       wrapper = mount(FabButton());
       wrapper.unmount();
       expect(fabInstanceDestroyMock).toHaveBeenCalled();
+    });
+    test('renders FloatingActionButton with passed styles', () => {
+      const style = { bottom: '45px', right: '24px' };
+      wrapper = mount(FabButton(true, style));
+      expect(wrapper.props().style.bottom).toEqual(style.bottom);
+      expect(wrapper.props().style.right).toEqual(style.right);
     });
   });
 });


### PR DESCRIPTION
# Description

Summary: Change FAB button so it can receive custom styles in its declaration.
Motivation: Now we can customize FAB and change its position on screen (not only on bottom right)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- unit testing
- browser testing

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
