### PR TITLE
Allow the use of `picture` HTML element in Parallax component

### DIFF
--- a/src/Parallax.js
+++ b/src/Parallax.js
@@ -15,7 +15,7 @@ class Parallax extends Component {
   }
 
   render() {
-    const { children, className, imageSrc, ...props } = this.props;
+    const { children, className, image, ...props } = this.props;
 
     delete props.options;
 
@@ -28,7 +28,7 @@ class Parallax extends Component {
             this._parallax = div;
           }}
         >
-          <img src={imageSrc} />
+          {image}
         </div>
       </div>
     );
@@ -39,9 +39,9 @@ Parallax.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   /**
-   * The image path which will be used for the background of the parallax
+   * The image which will be used for the background of the parallax
    */
-  imageSrc: PropTypes.string.isRequired,
+  image: PropTypes.node.isRequired,
   options: PropTypes.shape({
     /**
      * The minimum width of the screen, in pixels, where the parallax functionality starts working.

--- a/test/Parallax.spec.js
+++ b/test/Parallax.spec.js
@@ -59,5 +59,17 @@ describe('<Parallax />', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    test('can render a picture element', () => {
+      const pictureTag = (
+        <picture>
+          <source srcSet="#" type="image/webp" />
+          <source srcSet="#" type="image/jpg" />
+          <img src="#" alt="" />
+        </picture>
+      );
+
+      expect(shallow(<Parallax image={pictureTag} />)).toMatchSnapshot();
+    });
   });
 });

--- a/test/__snapshots__/Parallax.spec.js.snap
+++ b/test/__snapshots__/Parallax.spec.js.snap
@@ -1,19 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Parallax /> initialises can render a picture element 1`] = `
+<div
+  className="parallax-container"
+>
+  <div
+    className="parallax"
+  >
+    <picture>
+      <source
+        srcSet="#"
+        type="image/webp"
+      />
+      <source
+        srcSet="#"
+        type="image/jpg"
+      />
+      <img
+        alt=""
+        src="#"
+      />
+    </picture>
+  </div>
+</div>
+`;
+
 exports[`<Parallax /> initialises can render children element 1`] = `
 <div
   className="parallax-container"
+  imageSrc="image.jpg"
 >
   <h1>
     Test
   </h1>
   <div
     className="parallax"
-  >
-    <img
-      src="image.jpg"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -23,8 +45,6 @@ exports[`<Parallax /> should render a Parallax 1`] = `
 >
   <div
     className="parallax"
-  >
-    <img />
-  </div>
+  />
 </div>
 `;


### PR DESCRIPTION
# Description

As in #701 , you can now use a `picture` html element for art direction or simply to provide different version of your images (`WebP` images, `JPEG`...)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Add test to check if one can use a `picture` element
Updated every snapshots.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
