### PR TITLE
Fixes #792. Pass value prop as value to input

### DIFF
--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -44,6 +44,7 @@ class TextInput extends Component {
       password,
       email,
       validate,
+      defaultValue,
       value,
       type,
       ...other
@@ -76,7 +77,8 @@ class TextInput extends Component {
       placeholder,
       type: computedType,
       id: this.id,
-      defaultValue: value,
+      value: value,
+      defaultValue: defaultValue,
       disabled,
       ...other
     };
@@ -164,8 +166,12 @@ TextInput.propTypes = {
    * label text
    */
   label: PropTypes.string,
-  /*
+   /*
    * Input initial value
+   */
+  defaultValue: PropTypes.string,
+  /*
+   * Input value
    */
   value: PropTypes.string,
   /*


### PR DESCRIPTION
Fixes #792

# Description

Pass value prop as value to input in order to have ability to make input controlled.
add defaultValue prop

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
