### PR TITLE
feat: render a different menu on mobile

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -20,6 +20,7 @@ class Navbar extends Component {
   render() {
     const {
       children,
+      mobileNav,
       brand,
       className,
       extendWith,
@@ -73,7 +74,7 @@ class Navbar extends Component {
             this._sidenav = ul;
           }}
         >
-          {links}
+          {mobileNav || links}
         </ul>
       </Fragment>
     );
@@ -83,6 +84,7 @@ class Navbar extends Component {
 Navbar.propTypes = {
   brand: PropTypes.node,
   children: PropTypes.node,
+  mobileNav: PropTypes.node,
   className: PropTypes.string,
   extendWith: PropTypes.node,
   /**

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -84,6 +84,10 @@ class Navbar extends Component {
 Navbar.propTypes = {
   brand: PropTypes.node,
   children: PropTypes.node,
+  /**
+   * When your nav bar is resized, if mobileNav is provided it will be used as a menu in the sidenav.
+   * Otherwise the same links used in the desktop version will be shown.
+   */
   mobileNav: PropTypes.node,
   className: PropTypes.string,
   extendWith: PropTypes.node,

--- a/test/Navbar.spec.js
+++ b/test/Navbar.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { shallow, mount } from 'enzyme';
 import Navbar from '../src/Navbar';
 import mocker from './helper/new-mocker';
@@ -102,5 +102,25 @@ describe('<Navbar />', () => {
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('.breadcrumb')).toHaveLength(3);
+  });
+
+  test('can render a different menu on mobile devices', () => {
+    wrapper = shallow(
+      <Navbar
+        brand={<a href="/">Logo</a>}
+        mobileNav={
+          <Fragment>
+            <a href="#!">Mobile link 1</a>
+            <a href="#!">Mobile link 2</a>
+          </Fragment>
+        }
+      >
+        <a href="get-started.html">Getting started</a>
+        <a href="components.html">Components</a>
+      </Navbar>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('nav')).toHaveLength(1);
   });
 });

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -182,6 +182,71 @@ exports[`<Navbar /> can center the brand logo 1`] = `
 </Fragment>
 `;
 
+exports[`<Navbar /> can render a different menu on mobile devices 1`] = `
+<Fragment>
+  <nav
+    className=""
+  >
+    <div
+      className="nav-wrapper"
+    >
+      <a
+        className="brand-logo"
+        href="/"
+      >
+        Logo
+      </a>
+      <a
+        className="sidenav-trigger"
+        data-target="mobile-nav"
+        href="#!"
+      >
+        <Icon>
+          menu
+        </Icon>
+      </a>
+      <ul
+        className="hide-on-med-and-down "
+      >
+        <li
+          key="0/.0"
+        >
+          <a
+            href="get-started.html"
+          >
+            Getting started
+          </a>
+        </li>
+        <li
+          key="1/.1"
+        >
+          <a
+            href="components.html"
+          >
+            Components
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+  <ul
+    className="sidenav "
+    id="mobile-nav"
+  >
+    <a
+      href="#!"
+    >
+      Mobile link 1
+    </a>
+    <a
+      href="#!"
+    >
+      Mobile link 2
+    </a>
+  </ul>
+</Fragment>
+`;
+
 exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
 <Fragment>
   <nav


### PR DESCRIPTION
# Description

It's now possible to use a different menu for mobile devices.
This is needed, for example, when using a `Dropdown` component on the `Navbar`.
As it's not the best UX on mobile it's a good idea to use a different menu for these devices.

This `PR` adds a `mobileNav` prop which serve exactly this purpose.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added a new test.
Updated snapshots.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
