### PR TITLE
Swipeable Tabs broken and className not passed to Tab

### DIFF
--- a/src/Tab.js
+++ b/src/Tab.js
@@ -1,33 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Col from './Col';
 
 // This is just a holder for the props and children for tab, thus
 // there is no logic here.
-class Tab extends React.Component {
-  render() {
-    return null;
-  }
-}
-
+const Tab = ({ children, idx, className }) => (
+  <Col id={`tab_${idx}`} s={12} className={className}>
+    {children}
+  </Col>
+);
 Tab.propTypes = {
-  /**
-   * The title shown in the tabs list
-   */
-  title: PropTypes.node.isRequired,
-  /**
-   * The width of the Tab
-   */
-  tabWidth: PropTypes.number,
-  /**
-   * Pre-select the tab
-   * @default false
-   */
-  active: PropTypes.bool,
-  /**
-   * Disable the tab
-   * @default false
-   */
-  disabled: PropTypes.bool
+  children: PropTypes.node,
+  idx: PropTypes.string,
+  className: PropTypes.string
 };
 
 Tab.defaultProps = {

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import idgen from './idgen';
 import cx from 'classnames';
 
 import Row from './Row';
-import Col from './Col';
+import Tab from './Tab';
 
 class Tabs extends Component {
   constructor(props) {
@@ -19,19 +19,19 @@ class Tabs extends Component {
   }
 
   componentDidMount() {
-    const { tabOptions = {} } = this.props;
+    const { options } = this.props;
 
     if (typeof M !== 'undefined') {
-      this.instance = M.Tabs.init(this._tabsEl, tabOptions);
+      this.instance = M.Tabs.init(this._tabsEl, options);
     }
   }
 
   componentDidUpdate() {
-    const { tabOptions = {} } = this.props;
+    const { options } = this.props;
 
     if (typeof M !== 'undefined') {
       this.instance.destroy();
-      this.instance = M.Tabs.init(this._tabsEl, tabOptions);
+      this.instance = M.Tabs.init(this._tabsEl, options);
     }
   }
 
@@ -44,59 +44,44 @@ class Tabs extends Component {
   render() {
     const { children, className, defaultValue } = this.props;
     return (
-      <Row>
-        <Col s={12}>
-          <ul className={cx('tabs', className)} ref={el => (this._tabsEl = el)}>
-            {React.Children.map(children, (child, id) => {
-              const idx = `${this.scope}${id}`;
-              const {
-                active,
-                className,
-                disabled,
-                tabWidth,
-                title
-              } = child.props;
+      <Fragment>
+        <ul className={cx('tabs', className)} ref={el => (this._tabsEl = el)}>
+          {React.Children.map(children, (child, id) => {
+            const idx = `${this.scope}${id}`;
+            const { active, disabled, tabWidth, title } = child.props;
 
-              const classes = {
-                [`s${tabWidth}`]: tabWidth,
-                tab: true,
-                disabled,
-                col: true
-              };
+            const classes = {
+              [`s${tabWidth}`]: tabWidth,
+              tab: true,
+              disabled,
+              col: true
+            };
 
-              return (
-                <li className={cx(classes, className)} key={idx}>
-                  <a
-                    href={`#tab_${idx}`}
-                    className={active || defaultValue === idx ? 'active' : ''}
-                    {...(disabled
-                      ? {}
-                      : { onClick: this._onSelect.bind(this, idx) })}
-                  >
-                    {title}
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-        </Col>
-        {React.Children.map(children, (child, id) => {
-          const idx = `${this.scope}${id}`;
-          return (
-            <Col
-              id={`tab_${idx}`}
-              s={12}
-              key={`tab${idx}`}
-              style={{
-                display:
-                  child.props.active || defaultValue === idx ? 'block' : 'none'
-              }}
-            >
-              {child.props.children}
-            </Col>
-          );
-        })}
-      </Row>
+            return (
+              <li className={cx(classes)} key={idx}>
+                <a
+                  href={`#tab_${idx}`}
+                  className={active || defaultValue === idx ? 'active' : ''}
+                  {...(disabled
+                    ? {}
+                    : { onClick: this._onSelect.bind(this, idx) })}
+                >
+                  {title}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+        <Row>
+          {React.Children.map(children, (child, id) => {
+            const idx = `${this.scope}${id}`;
+            return cloneElement(child, {
+              defaultValue,
+              idx
+            });
+          })}
+        </Row>
+      </Fragment>
     );
   }
 }
@@ -110,7 +95,7 @@ Tabs.propTypes = {
    * More info
    * <a href='http://materializecss.com/tabs.html'>http://materializecss.com/tabs.html</a>
    */
-  tabOptions: PropTypes.shape({
+  options: PropTypes.shape({
     /*
      * Transition duration in milliseconds.
      * @default 300
@@ -132,6 +117,15 @@ Tabs.propTypes = {
      */
     responsiveThreshold: PropTypes.number
   })
+};
+
+Tab.defaultProps = {
+  options: {
+    duration: 300,
+    onShow: null,
+    swipeable: false,
+    responsiveThreshold: Infinity
+  }
 };
 
 export default Tabs;

--- a/stories/Tabs.stories.js
+++ b/stories/Tabs.stories.js
@@ -21,3 +21,36 @@ stories.add('Default', () => (
     <Tab title="Test 4">Test 4</Tab>
   </Tabs>
 ));
+
+stories.add('Swipeable Tabs', () => (
+  <Tabs
+    className="tab-demo z-depth-1"
+    options={{
+      swipeable: true
+    }}
+  >
+    <Tab title="Test 1" className="blue">
+      Test 1
+    </Tab>
+    <Tab title="Test 2" active className="red">
+      Test 2
+    </Tab>
+    <Tab title="Test 3" className="green">
+      Test 3
+    </Tab>
+  </Tabs>
+));
+
+stories.add('Fixed Width Tabs', () => (
+  <Tabs className="tab-demo z-depth-1 tabs-fixed-width">
+    <Tab title="Test 1">Test 1</Tab>
+    <Tab title="Test 2" active>
+      Test 2
+    </Tab>
+    <Tab title="Test 3" disabled>
+      Test 3
+    </Tab>
+    <Tab title="Test 4">Test 4</Tab>
+    <Tab title="Test 4">Test 5</Tab>
+  </Tabs>
+));

--- a/test/Tabs.spec.js
+++ b/test/Tabs.spec.js
@@ -40,14 +40,14 @@ describe('Tabs', () => {
     tabsInitMock.mockClear();
   });
 
-  test('should create list of Tab itemt', () => {
+  test('should create list of Tab items', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('with options', () => {
     beforeEach(() => {
       wrapper = mount(
-        <Tabs tabOptions={options}>
+        <Tabs options={options}>
           <Tab title="one">One</Tab>
           <Tab title="Two">Two</Tab>
         </Tabs>
@@ -62,7 +62,7 @@ describe('Tabs', () => {
   describe('when updated', () => {
     beforeEach(() => {
       wrapper = mount(
-        <Tabs tabOptions={options}>
+        <Tabs options={options}>
           <Tab title="one">One</Tab>
           <Tab title="Two">Two</Tab>
         </Tabs>

--- a/test/__snapshots__/Tabs.spec.js.snap
+++ b/test/__snapshots__/Tabs.spec.js.snap
@@ -1,62 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tabs should create list of Tab itemt 1`] = `
-<Row>
-  <Col
-    s={12}
+exports[`Tabs should create list of Tab items 1`] = `
+<Fragment>
+  <ul
+    className="tabs"
   >
-    <ul
-      className="tabs"
+    <li
+      className="tab col"
+      key="mockId0/.0"
     >
-      <li
-        className="tab col"
-        key="mockId0/.0"
+      <a
+        className=""
+        href="#tab_mockId0"
+        onClick={[Function]}
       >
-        <a
-          className=""
-          href="#tab_mockId0"
-          onClick={[Function]}
-        >
-          one
-        </a>
-      </li>
-      <li
-        className="tab col"
-        key="mockId1/.1"
+        one
+      </a>
+    </li>
+    <li
+      className="tab col"
+      key="mockId1/.1"
+    >
+      <a
+        className=""
+        href="#tab_mockId1"
+        onClick={[Function]}
       >
-        <a
-          className=""
-          href="#tab_mockId1"
-          onClick={[Function]}
-        >
-          Two
-        </a>
-      </li>
-    </ul>
-  </Col>
-  <Col
-    id="tab_mockId0"
-    key="tabmockId0/.0"
-    s={12}
-    style={
-      Object {
-        "display": "none",
+        Two
+      </a>
+    </li>
+  </ul>
+  <Row>
+    <Tab
+      idx="mockId0"
+      key=".0"
+      options={
+        Object {
+          "duration": 300,
+          "onShow": null,
+          "responsiveThreshold": Infinity,
+          "swipeable": false,
+        }
       }
-    }
-  >
-    One
-  </Col>
-  <Col
-    id="tab_mockId1"
-    key="tabmockId1/.1"
-    s={12}
-    style={
-      Object {
-        "display": "none",
+      title="one"
+    >
+      One
+    </Tab>
+    <Tab
+      idx="mockId1"
+      key=".1"
+      options={
+        Object {
+          "duration": 300,
+          "onShow": null,
+          "responsiveThreshold": Infinity,
+          "swipeable": false,
+        }
       }
-    }
-  >
-    Two
-  </Col>
-</Row>
+      title="Two"
+    >
+      Two
+    </Tab>
+  </Row>
+</Fragment>
 `;


### PR DESCRIPTION
# Description

With this P.R we refactor `Tab` and `Tabs` component:

- `swipeable` option now correctly works;
- Renamed `tabOptions` to `options` as this is the approach used in every other component;
- It's now possible to pass `className` both to `Tabs` and `Tab` component;
- Added missing stories;

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated specs.
Updated snapshots.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
