### PR TITLE
Select component with dynamic children

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1,6 +1,7 @@
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import Icon from './Icon';
 import idgen from './idgen';
 import constants from './constants';
 
@@ -27,8 +28,26 @@ class Select extends Component {
   }
 
   componentDidMount() {
+    const { options } = this.props;
+
     if (typeof M !== 'undefined') {
-      this.instance = M.FormSelect.init(this._selectRef);
+      this.instance = M.FormSelect.init(this._selectRef, options);
+    }
+  }
+
+  componentDidUpdate() {
+    const { options } = this.props;
+
+    if (this.instance) {
+      this.instance.destroy();
+    }
+
+    this.instance = M.FormSelect.init(this._selectRef, options);
+  }
+
+  componentWillUnmount() {
+    if (this.instance) {
+      this.instance.destroy();
     }
   }
 
@@ -37,6 +56,7 @@ class Select extends Component {
       s,
       m,
       l,
+      xl,
       disabled,
       noLayout,
       browserDefault,
@@ -47,12 +67,10 @@ class Select extends Component {
       error,
       validate,
       children,
-      multiple,
-      value,
-      type
+      multiple
     } = this.props;
 
-    const sizes = { s, m, l };
+    const sizes = { s, m, l, xl };
 
     let responsiveClasses;
     if (!noLayout) {
@@ -83,13 +101,12 @@ class Select extends Component {
         </label>
       );
 
-    const renderIcon = () =>
-      icon && <i className="material-icons prefix">{icon}</i>;
+    const renderIcon = () => icon && <Icon className="prefix">{icon}</Icon>;
 
     const renderOption = child =>
-      React.cloneElement(child, { key: child.props.value });
+      cloneElement(child, { key: child.props.value });
 
-    const renderOptions = () => React.Children.map(children, renderOption);
+    const renderOptions = () => Children.map(children, renderOption);
 
     return (
       <div className={wrapperClasses}>
@@ -128,17 +145,21 @@ Select.propTypes = {
    */
   noLayout: PropTypes.bool,
   /*
-   * Responsive size for Small
+   * Responsive size for small size screens (Mobile Devices <= 600px)
    */
   s: PropTypes.number,
   /*
-   * Responsive size for Medium
+   * Responsive size for middle size screens (Tablet Devices > 600px)
    */
   m: PropTypes.number,
   /*
-   * Responsive size for Large
+   * Responsive size for large size screens (Desktop Devices > 992px)
    */
   l: PropTypes.number,
+  /**
+   * Responsive size for extra large screens (Large Desktop Devices > 1200px)
+   */
+  xl: PropTypes.number,
   /*
    * disabled input
    */
@@ -190,7 +211,54 @@ Select.propTypes = {
    * to get array of selected values
    */
   multiple: PropTypes.bool,
-  children: PropTypes.any
+  children: PropTypes.any,
+  /**
+   * Options for the select
+   * <a target="_blank" href="https://materializecss.com/select.html#options">https://materializecss.com/select.html</a>
+   */
+  options: PropTypes.shape({
+    classes: PropTypes.string,
+    /**
+     * Options for the dropdown
+     * <a target="_blank" href="http://materializecss.com/dropdown.html#options">http://materializecss.com/dropdown.html</a>
+     */
+    dropdownOptions: PropTypes.shape({
+      alignment: PropTypes.oneOf(['left', 'right']),
+      autoTrigger: PropTypes.bool,
+      constrainWidth: PropTypes.bool,
+      container: PropTypes.node,
+      coverTrigger: PropTypes.bool,
+      closeOnClick: PropTypes.bool,
+      hover: PropTypes.bool,
+      inDuration: PropTypes.number,
+      outDuration: PropTypes.number,
+      onOpenStart: PropTypes.func,
+      onOpenEnd: PropTypes.func,
+      onCloseStart: PropTypes.func,
+      onCloseEnd: PropTypes.func
+    })
+  })
+};
+
+Select.defaultProps = {
+  options: {
+    classes: '',
+    dropdownOptions: {
+      alignment: 'left',
+      autoTrigger: true,
+      constrainWidth: true,
+      container: null,
+      coverTrigger: true,
+      closeOnClick: true,
+      hover: false,
+      inDuration: 150,
+      outDuration: 250,
+      onOpenStart: null,
+      onOpenEnd: null,
+      onCloseStart: null,
+      onCloseEnd: null
+    }
+  }
 };
 
 export default Select;

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -13,8 +13,19 @@ stories.addParameters({
 });
 
 stories.add('Default', () => (
-  <Select onChange={action('Select changed')}>
-    <option value="" disabled selected>
+  <Select value="" onChange={action('Select changed')}>
+    <option value="" disabled>
+      Choose your option
+    </option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+  </Select>
+));
+
+stories.add('with Icon', () => (
+  <Select value="" icon="cloud">
+    <option value="" disabled>
       Choose your option
     </option>
     <option value="1">Option 1</option>
@@ -24,8 +35,8 @@ stories.add('Default', () => (
 ));
 
 stories.add('Multiple', () => (
-  <Select multiple>
-    <option value="" disabled selected>
+  <Select multiple value="">
+    <option value="" disabled>
       Choose your option
     </option>
     <option value="1">Option 1</option>
@@ -35,31 +46,35 @@ stories.add('Multiple', () => (
 ));
 
 stories.add('Label', () => (
-  <Select label="Choose your option">
+  <Select label="Choose your option" value="2">
     <option value="1">Option 1</option>
-    <option value="2" selected>
-      Option 2
-    </option>
+    <option value="2">Option 2</option>
     <option value="3">Option 3</option>
   </Select>
 ));
 
 stories.add('Disabled', () => (
-  <Select disabled>
+  <Select disabled value="2">
     <option value="1">Option 1</option>
-    <option value="2" selected>
-      Option 2
-    </option>
+    <option value="2">Option 2</option>
     <option value="3">Option 3</option>
   </Select>
 ));
 
-stories.add('Browser default', () => (
-  <Select browserDefault>
+const browserDefault = storiesOf('Components|Select/Browser default', module);
+
+browserDefault.add('Default', () => (
+  <Select browserDefault value="2">
     <option value="1">Option 1</option>
-    <option value="2" selected>
-      Option 2
-    </option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+  </Select>
+));
+
+browserDefault.add('Disabled', () => (
+  <Select disabled browserDefault value="2">
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
     <option value="3">Option 3</option>
   </Select>
 ));

--- a/test/Select.spec.js
+++ b/test/Select.spec.js
@@ -89,6 +89,10 @@ describe('<Select />', () => {
       selectInstanceDestroyMock.mockClear();
     });
 
+    afterAll(() => {
+      restore();
+    });
+
     test('calls FormSelect', () => {
       mount(<Select />);
 

--- a/test/Select.spec.js
+++ b/test/Select.spec.js
@@ -52,7 +52,7 @@ describe('<Select />', () => {
 
   test('with icon', () => {
     wrapper = shallow(<Select icon="cloud" />);
-    expect(wrapper.find('i.material-icons.prefix')).toHaveLength(1);
+    expect(wrapper).toMatchSnapshot();
   });
 
   test('renders options', () => {
@@ -93,6 +93,29 @@ describe('<Select />', () => {
       mount(<Select />);
 
       expect(selectInitMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('with default options if none are given', () => {
+      mount(<Select />);
+
+      expect(selectInitMock).toHaveBeenCalledWith({
+        classes: '',
+        dropdownOptions: {
+          alignment: 'left',
+          autoTrigger: true,
+          constrainWidth: true,
+          container: null,
+          coverTrigger: true,
+          closeOnClick: true,
+          hover: false,
+          inDuration: 150,
+          outDuration: 250,
+          onOpenStart: null,
+          onOpenEnd: null,
+          onCloseStart: null,
+          onCloseEnd: null
+        }
+      });
     });
   });
 });

--- a/test/__snapshots__/Select.spec.js.snap
+++ b/test/__snapshots__/Select.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Select /> with icon 1`] = `
+<div
+  className="input-field col"
+>
+  <Icon
+    className="prefix"
+  >
+    cloud
+  </Icon>
+  <select
+    className=""
+    id="mockId"
+    onChange={[Function]}
+    type="select"
+  />
+</div>
+`;


### PR DESCRIPTION
# Description

This __P.R__  is for #811 .

I took the occasion to also:

- `Select` now uses `Icon`
- Add `defaultProps`
- Make it possible to use `options` (as per the [docs](https://materializecss.com/select.html#options))
- Added a new `spec`
- Add a new `story` and reorganize the old ones

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added a `spec` to check if the `Select` component is initialized with default options if none are given.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
