### PR TITLE
fix: dynamically update `checked` props

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import idgen from './idgen';
 
 const Checkbox = ({
+  className,
   checked,
   onChange,
   filledIn,
@@ -11,27 +12,24 @@ const Checkbox = ({
   disabled,
   value,
   id,
-  indeterminate
+  indeterminate,
+  ...other
 }) => {
-  let computedId;
-  if (indeterminate) {
-    computedId = 'indeterminate-checkbox';
-  } else if (id) {
-    computedId = id;
-  } else {
-    computedId = idgen();
-  }
+  const computedId =
+    id ||
+    (indeterminate ? `indeterminate-checkbox${idgen()}` : `checkbox${idgen()}`);
 
   return (
     <label htmlFor={computedId}>
       <input
         id={computedId}
-        className={cx({ 'filled-in': filledIn })}
+        className={cx({ 'filled-in': filledIn }, className)}
         disabled={disabled}
         onChange={onChange}
         type="checkbox"
-        defaultChecked={checked}
+        checked={checked}
         value={value}
+        {...other}
       />
       <span>{label}</span>
     </label>
@@ -39,6 +37,7 @@ const Checkbox = ({
 };
 
 Checkbox.propTypes = {
+  className: PropTypes.string,
   /*
    * checkbox value
    */
@@ -69,7 +68,7 @@ Checkbox.propTypes = {
    */
   disabled: PropTypes.bool,
   /*
-   * initialise checkbox checked
+   * A Boolean attribute indicating whether or not this checkbox is checked
    */
   checked: PropTypes.bool
 };

--- a/test/Checkbox.spec.js
+++ b/test/Checkbox.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Checkbox from '../src/Checkbox';
 import idgen from '../src/idgen';
 
@@ -36,7 +36,13 @@ describe('<Checkbox />', () => {
 
   test('with indeterminate', () => {
     wrapper = shallow(<Checkbox value="red" label="red" indeterminate />);
-    expect(idgen).not.toHaveBeenCalled();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('does not overwrite materialize-css classnames', () => {
+    wrapper = mount(
+      <Checkbox value="red" label="red" filledIn className="my-class" />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/test/__snapshots__/Checkbox.spec.js.snap
+++ b/test/__snapshots__/Checkbox.spec.js.snap
@@ -1,12 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Checkbox /> does not overwrite materialize-css classnames 1`] = `
+<Checkbox
+  className="my-class"
+  filledIn={true}
+  label="red"
+  value="red"
+>
+  <label
+    htmlFor="checkboxmockId"
+  >
+    <input
+      className="filled-in my-class"
+      id="checkboxmockId"
+      type="checkbox"
+      value="red"
+    />
+    <span>
+      red
+    </span>
+  </label>
+</Checkbox>
+`;
+
 exports[`<Checkbox /> filled-in 1`] = `
 <label
-  htmlFor="mockId"
+  htmlFor="checkboxmockId"
 >
   <input
     className="filled-in"
-    id="mockId"
+    id="checkboxmockId"
     type="checkbox"
     value="red"
   />
@@ -18,11 +41,11 @@ exports[`<Checkbox /> filled-in 1`] = `
 
 exports[`<Checkbox /> renders 1`] = `
 <label
-  htmlFor="mockId"
+  htmlFor="checkboxmockId"
 >
   <input
     className=""
-    id="mockId"
+    id="checkboxmockId"
     type="checkbox"
     value="red"
   />
@@ -34,12 +57,12 @@ exports[`<Checkbox /> renders 1`] = `
 
 exports[`<Checkbox /> renders disabled 1`] = `
 <label
-  htmlFor="mockId"
+  htmlFor="checkboxmockId"
 >
   <input
     className=""
     disabled={true}
-    id="mockId"
+    id="checkboxmockId"
     type="checkbox"
     value="red"
   />
@@ -67,11 +90,11 @@ exports[`<Checkbox /> with id 1`] = `
 
 exports[`<Checkbox /> with indeterminate 1`] = `
 <label
-  htmlFor="indeterminate-checkbox"
+  htmlFor="indeterminate-checkboxmockId"
 >
   <input
     className=""
-    id="indeterminate-checkbox"
+    id="indeterminate-checkboxmockId"
     type="checkbox"
     value="red"
   />


### PR DESCRIPTION
# Description

Similar to #792 (resolved with #797), it was impossible for a `Checkbox` to be "controlled".
This should fix #823 

I also took the occasion to add the possibility to pass down `className`s and other properties to the `input` element.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new test to make sure to preserve `filled-in` materialize-css class when passing down other `className`s.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
