### PR TITLE
Could not find module in path: 'react-materialize/src/TextInput' 

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,14 @@
+# JavaScript Standard Style Guide: http://standardjs.com
+# https://github.com/feross/eslint-config-standard-react
+rules:
+  no-restricted-imports: [
+    "error",
+    {
+      "paths": [
+        "../src/",
+      ],
+      "patterns": [
+        "../src/*",
+      ]
+    }
+  ]

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment, Children } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from './Icon';
-import TextInput from '../src/TextInput';
+import TextInput from './TextInput';
 class Navbar extends Component {
   componentDidMount() {
     const { options } = this.props;

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -48,12 +48,12 @@ exports[`<Navbar /> adds a brand node 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down "
+        className="hide-on-med-and-down"
       />
     </div>
   </nav>
   <ul
-    className="sidenav "
+    className="sidenav"
     id="mobile-nav"
   />
 </Navbar>
@@ -77,7 +77,7 @@ exports[`<Navbar /> can be extended with custom elements 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down "
+        className="hide-on-med-and-down"
       />
     </div>
     <div
@@ -108,7 +108,7 @@ exports[`<Navbar /> can be extended with custom elements 1`] = `
     </div>
   </nav>
   <ul
-    className="sidenav "
+    className="sidenav"
     id="mobile-nav"
   />
 </Fragment>
@@ -135,13 +135,13 @@ exports[`<Navbar /> can be fixed 1`] = `
           </Icon>
         </a>
         <ul
-          className="hide-on-med-and-down "
+          className="hide-on-med-and-down"
         />
       </div>
     </nav>
   </div>
   <ul
-    className="sidenav "
+    className="sidenav"
     id="mobile-nav"
   />
 </Fragment>
@@ -171,12 +171,12 @@ exports[`<Navbar /> can center the brand logo 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down "
+        className="hide-on-med-and-down"
       />
     </div>
   </nav>
   <ul
-    className="sidenav "
+    className="sidenav"
     id="mobile-nav"
   />
 </Fragment>

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -48,12 +48,12 @@ exports[`<Navbar /> adds a brand node 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down"
+        className="hide-on-med-and-down "
       />
     </div>
   </nav>
   <ul
-    className="sidenav"
+    className="sidenav "
     id="mobile-nav"
   />
 </Navbar>
@@ -77,7 +77,7 @@ exports[`<Navbar /> can be extended with custom elements 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down"
+        className="hide-on-med-and-down "
       />
     </div>
     <div
@@ -108,7 +108,7 @@ exports[`<Navbar /> can be extended with custom elements 1`] = `
     </div>
   </nav>
   <ul
-    className="sidenav"
+    className="sidenav "
     id="mobile-nav"
   />
 </Fragment>
@@ -135,13 +135,13 @@ exports[`<Navbar /> can be fixed 1`] = `
           </Icon>
         </a>
         <ul
-          className="hide-on-med-and-down"
+          className="hide-on-med-and-down "
         />
       </div>
     </nav>
   </div>
   <ul
-    className="sidenav"
+    className="sidenav "
     id="mobile-nav"
   />
 </Fragment>
@@ -171,12 +171,12 @@ exports[`<Navbar /> can center the brand logo 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down"
+        className="hide-on-med-and-down "
       />
     </div>
   </nav>
   <ul
-    className="sidenav"
+    className="sidenav "
     id="mobile-nav"
   />
 </Fragment>


### PR DESCRIPTION
# Description

Since version `3.1.0`, as also noted by @jamesmart77 in #823, we have a `ModuleNotFoundError`:

```
Could not find module in path: 'react-materialize/src/TextInput' relative to '/node_modules/react-materialize/lib/Navbar.js'
```

This error has been unfortunately introduced in #813 

This __P.R__ fixes this

As a side note:
~How should we prevent this kind of error in the future, @alextrastero ?~
I've come up with this solution: 
using [`ESLint` `no-restricted-imports` rules
](https://eslint.org/docs/rules/no-restricted-imports) we can restrict the use of `../src/something`.

I've introduced this with [this `commit`](https://github.com/react-materialize/react-materialize/pull/832/commits/bfec950e325ded27c08419f70391bee74747f551).

Let me know if this is ok for you :smile:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
