### PR TITLE
It's now possible to use `picture` HTML element in Mediabox component

### DIFF
--- a/src/MediaBox.js
+++ b/src/MediaBox.js
@@ -1,13 +1,23 @@
-import React, { Component } from 'react';
+import { Component, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import idgen from './idgen';
 
 class MediaBox extends Component {
+  constructor(props) {
+    super(props);
+
+    this.id = props.id || `mediabox${idgen()}`;
+  }
+
   componentDidMount() {
     if (typeof M !== 'undefined') {
       const { options } = this.props;
 
-      this.instance = M.Materialbox.init(this._materialBoxed, options);
+      this.instance = M.Materialbox.init(
+        document.getElementById(this.id),
+        options
+      );
     }
   }
 
@@ -18,34 +28,30 @@ class MediaBox extends Component {
   }
 
   render() {
-    const { src, className, caption, ...props } = this.props;
+    const { image, className, caption, ...props } = this.props;
 
     delete props.options;
 
-    return (
-      <img
-        className={cx('materialboxed', className)}
-        data-caption={caption}
-        src={src}
-        ref={img => {
-          this._materialBoxed = img;
-        }}
-        {...props}
-      />
-    );
+    return cloneElement(image, {
+      id: this.id,
+      className: cx('materialboxed', className),
+      'data-caption': caption,
+      ...props
+    });
   }
 }
 
 MediaBox.propTypes = {
+  id: PropTypes.string,
   className: PropTypes.string,
   /**
    * The caption shown below the image when opened
    */
   caption: PropTypes.string,
   /**
-   * The path to the image
+   * The image
    */
-  src: PropTypes.string.isRequired,
+  image: PropTypes.node.isRequired,
   options: PropTypes.shape({
     /**
      * Transition in duration in milliseconds.

--- a/src/MediaBox.js
+++ b/src/MediaBox.js
@@ -20,6 +20,8 @@ class MediaBox extends Component {
   render() {
     const { src, className, caption, ...props } = this.props;
 
+    delete props.options;
+
     return (
       <img
         className={cx('materialboxed', className)}

--- a/src/MediaBox.js
+++ b/src/MediaBox.js
@@ -28,11 +28,11 @@ class MediaBox extends Component {
   }
 
   render() {
-    const { image, className, caption, ...props } = this.props;
+    const { children, className, caption, ...props } = this.props;
 
     delete props.options;
 
-    return cloneElement(image, {
+    return cloneElement(children, {
       id: this.id,
       className: cx('materialboxed', className),
       'data-caption': caption,
@@ -42,16 +42,13 @@ class MediaBox extends Component {
 }
 
 MediaBox.propTypes = {
+  children: PropTypes.node.isRequired,
   id: PropTypes.string,
   className: PropTypes.string,
   /**
    * The caption shown below the image when opened
    */
   caption: PropTypes.string,
-  /**
-   * The image
-   */
-  image: PropTypes.node.isRequired,
   options: PropTypes.shape({
     /**
      * Transition in duration in milliseconds.

--- a/stories/Media.stories.js
+++ b/stories/Media.stories.js
@@ -13,46 +13,73 @@ stories.addParameters({
   }
 });
 
-stories.add('Default', () => (
-  <MediaBox
-    src="https://lorempixel.com/350/350/nature/1"
-    caption="A demo media box1"
-  />
-));
+stories.add(
+  'Material Box',
+  () => (
+    <MediaBox>
+      <img
+        src="https://materializecss.com/images/sample-1.jpg"
+        width="650"
+        alt=""
+      />
+    </MediaBox>
+  ),
+  {
+    info: {
+      text: `Material box is a material design implementation of the Lightbox plugin. When a user clicks on an image that can be enlarged, Material box centers the image and enlarges it in a smooth, non-jarring manner. To dismiss the image, the user can either click on the image again, scroll away, or press the ESC key.`
+    }
+  }
+);
 
-stories.add('Slider', () => (
-  <Slider>
-    <Slide image={<img src="http://lorempixel.com/780/580/nature/1" alt="" />}>
-      <Caption>
-        <h3>This is our big Tagline!</h3>
-        <h5 className="light grey-text text-lighten-3">
-          Here's our small slogan.
-        </h5>
-      </Caption>
-    </Slide>
-    <Slide image={<img src="http://lorempixel.com/780/580/nature/2" alt="" />}>
-      <Caption placement="left">
-        <h3>Left Aligned Caption</h3>
-        <h5 className="light grey-text text-lighten-3">
-          Here's our small slogan.
-        </h5>
-      </Caption>
-    </Slide>
-    <Slide image={<img src="https://lorempixel.com/780/580/nature/3" alt="" />}>
-      <Caption placement="right">
-        <h3>Right Aligned Caption</h3>
-        <h5 className="light grey-text text-lighten-3">
-          Here's our small slogan.
-        </h5>
-      </Caption>
-    </Slide>
-    <Slide image={<img src="https://lorempixel.com/580/250/nature/4" alt="" />}>
-      <Caption>
-        <h3>This is our big Tagline!</h3>
-        <h5 className="light grey-text text-lighten-3">
-          Here's our small slogan.
-        </h5>
-      </Caption>
-    </Slide>
-  </Slider>
-));
+stories.add(
+  'Slider',
+  () => (
+    <Slider>
+      <Slide
+        image={<img src="http://lorempixel.com/780/580/nature/1" alt="" />}
+      >
+        <Caption>
+          <h3>This is our big Tagline!</h3>
+          <h5 className="light grey-text text-lighten-3">
+            Here's our small slogan.
+          </h5>
+        </Caption>
+      </Slide>
+      <Slide
+        image={<img src="http://lorempixel.com/780/580/nature/2" alt="" />}
+      >
+        <Caption placement="left">
+          <h3>Left Aligned Caption</h3>
+          <h5 className="light grey-text text-lighten-3">
+            Here's our small slogan.
+          </h5>
+        </Caption>
+      </Slide>
+      <Slide
+        image={<img src="https://lorempixel.com/780/580/nature/3" alt="" />}
+      >
+        <Caption placement="right">
+          <h3>Right Aligned Caption</h3>
+          <h5 className="light grey-text text-lighten-3">
+            Here's our small slogan.
+          </h5>
+        </Caption>
+      </Slide>
+      <Slide
+        image={<img src="https://lorempixel.com/580/250/nature/4" alt="" />}
+      >
+        <Caption>
+          <h3>This is our big Tagline!</h3>
+          <h5 className="light grey-text text-lighten-3">
+            Here's our small slogan.
+          </h5>
+        </Caption>
+      </Slide>
+    </Slider>
+  ),
+  {
+    info: {
+      text: `Our slider is a simple and elegant image carousel. You can also have captions that will be transitioned on their own depending on their alignment. You can also have indicators that show up on the bottom of the slider.`
+    }
+  }
+);

--- a/test/MediaBox.spec.js
+++ b/test/MediaBox.spec.js
@@ -25,7 +25,7 @@ describe('<MediaBox />', () => {
     wrapper = shallow(
       <MediaBox
         className="more"
-        src="image.jpg"
+        image={<img src="image.jpg" alt="" />}
         caption="A demo media box1"
         width="650"
       />
@@ -41,7 +41,7 @@ describe('<MediaBox />', () => {
     });
 
     test('calls Materialbox', () => {
-      mount(<MediaBox />);
+      mount(<MediaBox image={<img src="image.jpg" alt="" />} />);
 
       expect(materialboxInitMock).toHaveBeenCalledTimes(1);
     });
@@ -52,7 +52,9 @@ describe('<MediaBox />', () => {
         outDuration: 250
       };
 
-      mount(<MediaBox options={options} />);
+      mount(
+        <MediaBox image={<img src="image.jpg" alt="" />} options={options} />
+      );
 
       expect(materialboxInitMock).toHaveBeenCalledWith(options);
     });

--- a/test/MediaBox.spec.js
+++ b/test/MediaBox.spec.js
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import { shallow, mount } from 'enzyme';
 import MediaBox from '../src/MediaBox';
 import mocker from './helper/new-mocker';
 
 describe('<MediaBox />', () => {
-  let wrapper;
+  const wrapper = (
+    <MediaBox className="more" caption="A demo media box1" width="650">
+      <img src="image.jpg" alt="" />
+    </MediaBox>
+  );
   const materialboxInitMock = jest.fn();
   const materialboxInstanceDestroyMock = jest.fn();
   const materialboxMock = {
@@ -22,16 +26,7 @@ describe('<MediaBox />', () => {
   });
 
   test('renders', () => {
-    wrapper = shallow(
-      <MediaBox
-        className="more"
-        image={<img src="image.jpg" alt="" />}
-        caption="A demo media box1"
-        width="650"
-      />
-    );
-
-    expect(wrapper).toMatchSnapshot();
+    expect(shallow(wrapper)).toMatchSnapshot();
   });
 
   describe('initialises', () => {
@@ -41,7 +36,7 @@ describe('<MediaBox />', () => {
     });
 
     test('calls Materialbox', () => {
-      mount(<MediaBox image={<img src="image.jpg" alt="" />} />);
+      mount(wrapper);
 
       expect(materialboxInitMock).toHaveBeenCalledTimes(1);
     });
@@ -52,9 +47,7 @@ describe('<MediaBox />', () => {
         outDuration: 250
       };
 
-      mount(
-        <MediaBox image={<img src="image.jpg" alt="" />} options={options} />
-      );
+      mount(cloneElement(wrapper, { options }));
 
       expect(materialboxInitMock).toHaveBeenCalledWith(options);
     });

--- a/test/__snapshots__/MediaBox.spec.js.snap
+++ b/test/__snapshots__/MediaBox.spec.js.snap
@@ -2,8 +2,10 @@
 
 exports[`<MediaBox /> renders 1`] = `
 <img
+  alt=""
   className="materialboxed more"
   data-caption="A demo media box1"
+  id="mediaboxmockId"
   src="image.jpg"
   width="650"
 />

--- a/test/__snapshots__/MediaBox.spec.js.snap
+++ b/test/__snapshots__/MediaBox.spec.js.snap
@@ -4,16 +4,6 @@ exports[`<MediaBox /> renders 1`] = `
 <img
   className="materialboxed more"
   data-caption="A demo media box1"
-  options={
-    Object {
-      "inDuration": 275,
-      "onCloseEnd": null,
-      "onCloseStart": null,
-      "onOpenEnd": null,
-      "onOpenStart": null,
-      "outDuration": 200,
-    }
-  }
   src="image.jpg"
   width="650"
 />


### PR DESCRIPTION
# Description

As in #795 and #701, it's now possible to use a `picture` `HTML` element or a component like [`react-progressive-picture`](https://github.com/CloudPower97/react-progressive-picture) or [`react-responsive-picture`](https://github.com/braposo/react-responsive-picture) and similar.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added a new `spec`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
