### PR TITLE
fix: ensure components dont error when M is undefined

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -13,7 +13,7 @@ class Button extends Component {
   }
 
   componentDidMount() {
-    if (!M) return;
+    if (typeof M === 'undefined') return;
 
     const { tooltip, tooltipOptions = {}, fab } = this.props;
     if (tooltip) {

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -11,8 +11,9 @@ class Carousel extends React.Component {
 
   componentDidMount() {
     const { options } = this.props;
-
-    this.instance = M.Carousel.init(this._carousel, options);
+    if (options && typeof M !== 'undefined') {
+      this.instance = M.Carousel.init(this._carousel, options);
+    }
   }
 
   componentWillUnmount() {

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -15,10 +15,12 @@ class Collapsible extends Component {
   }
 
   componentDidMount() {
-    this.instance = M.Collapsible.init(this._collapsible, {
-      accordion: this.props.accordion,
-      ...this.props.options
-    });
+    if (typeof M !== 'undefined') {
+      this.instance = M.Collapsible.init(this._collapsible, {
+        accordion: this.props.accordion,
+        ...this.props.options
+      });
+    }
   }
 
   componentWillUnmount() {

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -11,7 +11,9 @@ class Slider extends Component {
   }
 
   initSlider() {
-    this.instance = M.Slider.init(this._slider, this.props.options);
+    if (typeof M !== 'undefined') {
+      this.instance = M.Slider.init(this._slider, this.props.options);
+    }
   }
 
   /**

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -22,7 +22,7 @@ class TextInput extends Component {
   componentDidUpdate(prevProps) {
     const { value } = this.props;
 
-    if (value !== prevProps.value) {
+    if (value !== prevProps.value && typeof M !== 'undefined') {
       M.updateTextFields();
     }
   }

--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -7,7 +7,9 @@ import constants from './constants';
 
 class Textarea extends Component {
   componentDidUpdate() {
-    M.textareaAutoResize(this._textarea);
+    if (typeof M !== 'undefined') {
+      M.textareaAutoResize(this._textarea);
+    }
   }
 
   renderIcon(icon, className) {

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -7,7 +7,7 @@ import Button from './Button';
 const Toast = props => {
   const { children, className, options = {} } = props;
 
-  const showToast = () => M.toast(options);
+  const showToast = () => (typeof M !== 'undefined' ? M.toast(options) : null);
 
   return (
     <Button onClick={showToast} className={cx('toast', className)}>

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -120,6 +120,23 @@ describe('Button', () => {
     });
   });
 
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      const tooltip = {};
+      expect(() =>
+        mount(<Button tooltip={tooltip}>Stuff</Button>)
+      ).not.toThrow();
+    });
+  });
+
   describe('with fixed action button', () => {
     const fabInitMock = jest.fn();
     const fabInstanceDestroyMock = jest.fn();

--- a/test/Carousel.spec.js
+++ b/test/Carousel.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Carousel from '../src/Carousel';
 import mocker from './helper/new-mocker';
 
@@ -102,6 +102,22 @@ describe('<Carousel />', () => {
       const options = { padding: 12, fullWidth: true, indicators: false };
       wrapper = shallow(<Carousel images={images} options={options} />);
       expect(carouselInitMock).toHaveBeenCalledWith(options);
+    });
+  });
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      const tooltip = {};
+      expect(() =>
+        mount(<Carousel options={{ fullWidth: true }} />)
+      ).not.toThrow();
     });
   });
 });

--- a/test/Collapsible.spec.js
+++ b/test/Collapsible.spec.js
@@ -142,4 +142,23 @@ describe('<Collapsible />', () => {
       .simulate('click');
     expect(onSelect).toHaveBeenCalledWith(clickedIndex);
   });
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      expect(() =>
+        mount(
+          <Collapsible accordion>
+            <CollapsibleItem header="A">A</CollapsibleItem>
+          </Collapsible>
+        )
+      ).not.toThrow();
+    });
+  });
 });

--- a/test/Slider.spec.js
+++ b/test/Slider.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Slider from '../src/Slider';
 import mocker from './helper/new-mocker';
 
@@ -72,5 +72,18 @@ describe('<Slider />', () => {
     wrapper.setProps(nextProps);
     expect(sliderInstanceDestroyMock).toHaveBeenCalled();
     expect(sliderInitMock.mock.calls[1][0]).toEqual(nextProps.options);
+  });
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      expect(() => mount(<Slider />)).not.toThrow();
+    });
   });
 });

--- a/test/TextInput.spec.js
+++ b/test/TextInput.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import TextInput from '../src/TextInput';
 import Icon from '../src/Icon';
 
@@ -74,6 +74,20 @@ describe('<TextInput />', () => {
 
       wrapper.find('Icon').simulate('click');
       expect(mockIconClick).toBeCalled();
+    });
+  });
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      const element = mount(<TextInput value="foo" />);
+      expect(() => element.setProps({ value: 'bar' })).not.toThrow();
     });
   });
 });

--- a/test/Textarea.spec.js
+++ b/test/Textarea.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Textarea from '../src/Textarea';
 
 describe('<Textarea />', () => {
@@ -53,5 +53,19 @@ describe('<Textarea />', () => {
     const textareaElement = wrapper.find('textarea');
     expect(textareaElement.hasClass('materialize-textarea')).toBeTruthy();
     expect(textareaElement.hasClass('custom-class')).toBeTruthy();
+  });
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      const element = mount(<Textarea />);
+      expect(() => element.setProps({ label: 'foo' })).not.toThrow();
+    });
   });
 });

--- a/test/Toast.spec.js
+++ b/test/Toast.spec.js
@@ -32,4 +32,18 @@ describe('Toast', () => {
     wrapper.simulate('click');
     expect(toastMock).toHaveBeenCalledWith(options);
   });
+  describe('undefined M', () => {
+    let __M;
+    beforeEach(() => {
+      __M = global.M;
+      global.M = undefined;
+    });
+    afterEach(() => {
+      global.M = __M;
+    });
+    test('doesnt throw without M', () => {
+      const undefWrapper = shallow(<Toast options={options}>{child}</Toast>);
+      expect(() => undefWrapper.simulate('click')).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
add checks to ensure M is not undefined before accessing its methods. includes tests to ensure
undefined checks are not removed in future.

https://github.com/react-materialize/react-materialize/issues/841
https://github.com/react-materialize/react-materialize/issues/836

# Description

Please include a summary of the change and which issue is fixed/what was added. Please also include relevant motivation and context.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests, ran them before applying the fixes, all failed, ran again after adding checks, all pass.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas - didn't think it required explanation, lmk if you think anything is unclear, its pretty trivial
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
