### PR TITLE
Parallax story now uses the correct props

### DIFF
--- a/stories/Parallax.stories.js
+++ b/stories/Parallax.stories.js
@@ -12,13 +12,25 @@ stories.addParameters({
 
 stories.add('Default', () => (
   <div>
-    <Parallax imageSrc="http://materializecss.com/images/parallax1.jpg"/>
+    <Parallax
+      image={
+        <img src="http://materializecss.com/images/parallax1.jpg" alt="" />
+      }
+    />
     <div className="section white">
       <div className="row container">
         <h2 className="header">Parallax</h2>
-        <p className="grey-text text-darken-3 lighten-3">Parallax is an effect where the background content or image in this case, is moved at a different speed than the foreground content while scrolling.</p>
+        <p className="grey-text text-darken-3 lighten-3">
+          Parallax is an effect where the background content or image in this
+          case, is moved at a different speed than the foreground content while
+          scrolling.
+        </p>
       </div>
     </div>
-    <Parallax imageSrc="http://materializecss.com/images/parallax2.jpg"/>
+    <Parallax
+      image={
+        <img src="http://materializecss.com/images/parallax2.jpg" alt="" />
+      }
+    />
   </div>
 ));


### PR DESCRIPTION
# Description

Apparently, `Parallax` `story` was not updated with #795.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
