### PR TITLE
Add Character Counter to TextInput

### DIFF
--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -19,6 +19,13 @@ class TextInput extends Component {
     }
   }
 
+  componentDidMount() {
+    if (typeof M !== undefined) {
+      // eslint-disable-next-line react/prop-types
+      this.props['data-length'] && M.CharacterCounter.init(this.inputRef);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { value } = this.props;
 

--- a/stories/TextInput.stories.js
+++ b/stories/TextInput.stories.js
@@ -46,6 +46,16 @@ stories.add('Email validate', () => (
   />
 ));
 
+stories.add(
+  'Character Counter',
+  () => <TextInput label="Input text" data-length={10} />,
+  {
+    info: {
+      text: `Use a character counter in fields where a character restriction is in place.`
+    }
+  }
+);
+
 stories.add('with custom error/success', () => (
   <TextInput
     email


### PR DESCRIPTION
# Description

As per the title, `data-length` `prop` now correctly initializes a [Character Counter](https://materializecss.com/text-inputs.html#character-counter) on `TextInput`.

Also added a new `story`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested it in a side project and through `Storybook`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
