### PR TITLE
Avoid non-unique id warning on TextInput

### DIFF
--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -11,11 +11,11 @@ class TextInput extends Component {
     this.id = props.id || idgen();
 
     if (props.password) {
-      this.id = 'password';
+      this.id = `password${idgen()}`;
     }
 
     if (props.email) {
-      this.id = 'email';
+      this.id = `email${idgen()}`;
     }
   }
 


### PR DESCRIPTION
# Description

From _Chrome 63_, the following error is thrown:

`[DOM] Found elements with non-unique id: (More info: [https://goo.gl/9p2vKq](https://goo.gl/9p2vKq))`

It seems that when `type` prop is set to either `password` or `email`, the `id` is simply `password` and `email` respectively;

This **P.R** fixes this by using `idgen` as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The error in the console is gone and the generated `id` is correctly applied to `TextInput`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
