### PR TITLE
Checkbox checked prop now correctly works

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -11,7 +11,7 @@ class Checkbox extends Component {
   componentDidMount() {
     const { indeterminate } = this.props;
 
-    if (this._input) {
+    if (this._input && indeterminate) {
       this._input.indeterminate = indeterminate;
       this._input.checked = false;
     }
@@ -26,6 +26,7 @@ class Checkbox extends Component {
   render() {
     const {
       id,
+      className,
       indeterminate,
       filledIn,
       disabled,
@@ -45,9 +46,12 @@ class Checkbox extends Component {
       <label htmlFor={computedId}>
         <input
           id={computedId}
-          className={cx({
-            'filled-in': filledIn
-          })}
+          className={cx(
+            {
+              'filled-in': filledIn
+            },
+            className
+          )}
           disabled={disabled}
           onChange={onChange}
           type="checkbox"

--- a/test/Checkbox.spec.js
+++ b/test/Checkbox.spec.js
@@ -40,6 +40,12 @@ describe('<Checkbox />', () => {
     expect(wrapper.find('input').instance().indeterminate).toBe(true);
   });
 
+  test('checked', () => {
+    wrapper = mount(<Checkbox value="red" label="red" checked />);
+    expect(wrapper.find('input').instance().checked).toBe(true);
+    expect(wrapper.find('input').instance().indeterminate).toBe(false);
+  });
+
   test('does not overwrite materialize-css classnames', () => {
     wrapper = mount(
       <Checkbox value="red" label="red" filledIn className="my-class" />

--- a/test/__snapshots__/Checkbox.spec.js.snap
+++ b/test/__snapshots__/Checkbox.spec.js.snap
@@ -11,7 +11,7 @@ exports[`<Checkbox /> does not overwrite materialize-css classnames 1`] = `
     htmlFor="mockId"
   >
     <input
-      className="filled-in"
+      className="filled-in my-class"
       id="mockId"
       type="checkbox"
       value="red"


### PR DESCRIPTION
# Description

This **P.R** is for #854.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new test to make sure that when `checked` `prop` is `true`, the relative `input` attribute `checked` is true.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
