### PR TITLE
Select other attributes

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -182,7 +182,7 @@ Select.propTypes = {
   /*
    * Input initial value
    */
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   /*
    * Add validate class to input
    */

--- a/src/Select.js
+++ b/src/Select.js
@@ -67,7 +67,8 @@ class Select extends Component {
       error,
       validate,
       children,
-      multiple
+      multiple,
+      ...other
     } = this.props;
 
     const sizes = { s, m, l, xl };
@@ -87,7 +88,8 @@ class Select extends Component {
       id: this.id,
       value: this.state.value,
       disabled,
-      multiple
+      multiple,
+      ...other
     };
 
     const renderLabel = () =>

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -35,7 +35,7 @@ stories.add('with Icon', () => (
 ));
 
 stories.add('Multiple', () => (
-  <Select multiple value="">
+  <Select multiple value={['']}>
     <option value="" disabled>
       Choose your option
     </option>

--- a/test/Select.spec.js
+++ b/test/Select.spec.js
@@ -71,6 +71,11 @@ describe('<Select />', () => {
     expect(wrapper.find('select.multiple')).toHaveLength(1);
   });
 
+  test('handles other attributes', () => {
+    wrapper = shallow(<Select name="foo" />);
+    expect(wrapper.find('select').prop('name')).toBe('foo');
+  });
+
   describe('initialises', () => {
     const selectInitMock = jest.fn();
     const selectInstanceDestroyMock = jest.fn();

--- a/test/__snapshots__/Select.spec.js.snap
+++ b/test/__snapshots__/Select.spec.js.snap
@@ -13,6 +13,26 @@ exports[`<Select /> with icon 1`] = `
     className=""
     id="mockId"
     onChange={[Function]}
+    options={
+      Object {
+        "classes": "",
+        "dropdownOptions": Object {
+          "alignment": "left",
+          "autoTrigger": true,
+          "closeOnClick": true,
+          "constrainWidth": true,
+          "container": null,
+          "coverTrigger": true,
+          "hover": false,
+          "inDuration": 150,
+          "onCloseEnd": null,
+          "onCloseStart": null,
+          "onOpenEnd": null,
+          "onOpenStart": null,
+          "outDuration": 250,
+        },
+      }
+    }
     type="select"
   />
 </div>


### PR DESCRIPTION
# Select was not passing other props to `select` node.

Also we had some warnings in Storybook due to multiple select value prop.

Fixes #853