### PR TITLE
Feature allow prop.id for Navbar

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -98,6 +98,7 @@ class Navbar extends Component {
 }
 
 Navbar.propTypes = {
+  id: PropTypes.string,
   brand: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -5,11 +5,6 @@ import Icon from './Icon';
 import TextInput from './TextInput';
 
 class Navbar extends Component {
-  constructor(props) {
-    super(props);
-    this.idx = props.id || `mobile-nav`;
-  }
-
   componentDidMount() {
     const { options } = this.props;
 
@@ -26,6 +21,7 @@ class Navbar extends Component {
 
   render() {
     const {
+      id,
       children,
       brand,
       className,
@@ -64,7 +60,7 @@ class Navbar extends Component {
                 React.cloneElement(brand, {
                   className: cx(brand.props.className, brandClasses)
                 })}
-              <a href="#!" data-target={this.idx} className="sidenav-trigger">
+              <a href="#!" data-target={id} className="sidenav-trigger">
                 <Icon>menu</Icon>
               </a>
               <ul className={navMobileCSS}>{links}</ul>
@@ -84,7 +80,7 @@ class Navbar extends Component {
         {navbar}
 
         <ul
-          id={this.idx}
+          id={id}
           className={cx('sidenav', [alignLinks])}
           ref={ul => {
             this._sidenav = ul;
@@ -98,6 +94,10 @@ class Navbar extends Component {
 }
 
 Navbar.propTypes = {
+  /*
+   * override id
+   * @default 'mobile-nav'
+   */
   id: PropTypes.string,
   brand: PropTypes.node,
   children: PropTypes.node,
@@ -144,6 +144,7 @@ Navbar.propTypes = {
 };
 
 Navbar.defaultProps = {
+  id: 'mobile-nav',
   options: {
     edge: 'left',
     draggable: true,

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -5,6 +5,11 @@ import Icon from './Icon';
 import TextInput from './TextInput';
 
 class Navbar extends Component {
+  constructor(props) {
+    super(props);
+    this.idx = props.id || `mobile-nav`;
+  }
+
   componentDidMount() {
     const { options } = this.props;
 
@@ -59,7 +64,7 @@ class Navbar extends Component {
                 React.cloneElement(brand, {
                   className: cx(brand.props.className, brandClasses)
                 })}
-              <a href="#!" data-target="mobile-nav" className="sidenav-trigger">
+              <a href="#!" data-target={this.idx} className="sidenav-trigger">
                 <Icon>menu</Icon>
               </a>
               <ul className={navMobileCSS}>{links}</ul>
@@ -79,7 +84,7 @@ class Navbar extends Component {
         {navbar}
 
         <ul
-          id="mobile-nav"
+          id={this.idx}
           className={cx('sidenav', [alignLinks])}
           ref={ul => {
             this._sidenav = ul;

--- a/test/Navbar.spec.js
+++ b/test/Navbar.spec.js
@@ -103,4 +103,9 @@ describe('<Navbar />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('.breadcrumb')).toHaveLength(3);
   });
+
+  test('can have custom id', () => {
+    wrapper = shallow(<Navbar id="custom-id" />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -9,6 +9,7 @@ exports[`<Navbar /> adds a brand node 1`] = `
       I AM BRAND
     </span>
   }
+  id="mobile-nav"
   options={
     Object {
       "draggable": true,
@@ -287,5 +288,34 @@ exports[`<Navbar /> renders 1`] = `
       </a>
     </li>
   </ul>
+</Fragment>
+`;
+
+exports[`<Navbar /> can have custom id 1`] = `
+<Fragment>
+  <nav
+    className=""
+  >
+    <div
+      className="nav-wrapper"
+    >
+      <a
+        className="sidenav-trigger"
+        data-target="custom-id"
+        href="#!"
+      >
+        <Icon>
+          menu
+        </Icon>
+      </a>
+      <ul
+        className="hide-on-med-and-down "
+      />
+    </div>
+  </nav>
+  <ul
+    className="sidenav "
+    id="custom-id"
+  />
 </Fragment>
 `;


### PR DESCRIPTION
# Description

This adds the ability to define a custom ID for a navbar. This is useful in situations where-as the is a need for multiple navbars on the same page so that the mobile sidenav will work and not conflict because of duplicated ids

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

The default if no ID is defined for the Navbar component is to fallback to 'mobile-nav' thus there are no breaking changes

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
