### PR TITLE
Display error message for select as materialize expects it

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -36,7 +36,10 @@ class Select extends Component {
   }
 
   componentDidUpdate() {
-    const { options } = this.props;
+    let { options, error } = this.props;
+    if (error) {
+      options = { ...options, classes: cx(options.classes, 'invalid') };
+    }
 
     if (this.instance) {
       this.instance.destroy();
@@ -103,6 +106,15 @@ class Select extends Component {
         </label>
       );
 
+    const renderHelper = () =>
+      [error || success] && (
+        <span
+          className="helper-text"
+          data-error={error}
+          data-success={success}
+        />
+      );
+
     const renderIcon = () => icon && <Icon className="prefix">{icon}</Icon>;
 
     const renderOption = child =>
@@ -132,6 +144,7 @@ class Select extends Component {
           {renderOptions()}
         </select>
         {renderLabel()}
+        {renderHelper()}
       </div>
     );
   }

--- a/test/__snapshots__/Select.spec.js.snap
+++ b/test/__snapshots__/Select.spec.js.snap
@@ -35,5 +35,8 @@ exports[`<Select /> with icon 1`] = `
     }
     type="select"
   />
+  <span
+    className="helper-text"
+  />
 </div>
 `;


### PR DESCRIPTION
# Description

The error message for the Select component was not displayed as it is expected in Materialize. This change adds a span for the error message and adds 'invalid' class to the select wrapper. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I set the error prop to some value and the error was properly displayed and field was highlighted as invalid.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
