### PR TITLE
Fix defaultChecked property of Checkbox.js

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -55,7 +55,7 @@ class Checkbox extends Component {
           disabled={disabled}
           onChange={onChange}
           type="checkbox"
-          defaultChecked={checked}
+          checked={checked}
           value={value}
           ref={input => (this._input = input)}
         />


### PR DESCRIPTION
# Description

Changed Checkbox component. Replaced the `defaultChecked` property of inputs with the `checked` property. The Checkbox component was not properly re-rendering when sent new values.

I made an example in a tiny create-react-app. https://www.youtube.com/watch?v=MMo6gSKLVdA&feature=youtu.be

For some context on usage:
https://www.w3schools.com/jsref/prop_checkbox_defaultchecked.asp
https://www.w3schools.com/tags/att_input_checked.asp

This is basically solving the exact same issue as my previously merged change for RadioGroup.js, https://github.com/react-materialize/react-materialize/pull/883. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Create an instance of the Checkbox component and set the checked property to state variable
2. Update the state variable
3. Checkbox will not update

The only way to change checkbox checked status currently is by clicking on it.

After changing the property passed to inputs from `defaultChecked` to `checked`, the inputs will update when the checked property updates.

Ran `npm run test:unit -- -u` and then `npm run test`. All tests passing.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
