### PR TITLE
Not render helperText for InputText if !error. For decries height of InputText.

### DIFF
--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -107,7 +107,7 @@ class TextInput extends Component {
       );
 
     const renderHelper = () =>
-      [error || success] && (
+      (error || success) && (
         <span
           className="helper-text"
           data-error={error}


### PR DESCRIPTION
condition for render
before, always true:  [error || success] && (
after:  (error || success) && (
