### PR TITLE
fix: call updateData when providing new data

### DIFF
--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -25,6 +25,16 @@ class Autocomplete extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.instance) {
+      const { data } = this.props.options;
+
+      if (prevProps.options.data !== data) {
+        this.instance.updateData(data);
+      }
+    }
+  }
+
   componentWillUnmount() {
     if (this.instance) {
       this.instance.destroy();

--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -29,7 +29,7 @@ class Autocomplete extends Component {
     if (this.instance) {
       const { data } = this.props.options;
 
-      if (prevProps.options.data !== data) {
+      if (JSON.stringify(prevProps.options.data) !== JSON.stringify(data)) {
         this.instance.updateData(data);
       }
     }

--- a/test/Autocomplete.spec.js
+++ b/test/Autocomplete.spec.js
@@ -53,6 +53,7 @@ describe('<Autocomplete />', () => {
     beforeEach(() => {
       autocompleteInitMock.mockClear();
       autocompleteInstanceDestroyMock.mockClear();
+      autocompleteUpdateDataMock.mockClear();
     });
 
     afterAll(() => {
@@ -62,6 +63,7 @@ describe('<Autocomplete />', () => {
     test('calls Autocomplete', () => {
       mount(<Autocomplete />);
       expect(autocompleteInitMock).toHaveBeenCalledTimes(1);
+      expect(autocompleteUpdateDataMock).not.toHaveBeenCalled();
     });
 
     test('calls updateData when providing new data', () => {

--- a/test/Autocomplete.spec.js
+++ b/test/Autocomplete.spec.js
@@ -10,6 +10,7 @@ describe('<Autocomplete />', () => {
     Google: 'http://placehold.it/250x250',
     'Apple Inc': null
   };
+
   const componentId = 'testAutocompleteId';
 
   let wrapper;
@@ -36,24 +37,38 @@ describe('<Autocomplete />', () => {
 
   describe('initialises', () => {
     const autocompleteInitMock = jest.fn();
+    const autocompleteUpdateDataMock = jest.fn();
     const autocompleteInstanceDestroyMock = jest.fn();
     const autocompleteMock = {
       init: (el, options) => {
         autocompleteInitMock(options);
         return {
-          destroy: autocompleteInstanceDestroyMock
+          destroy: autocompleteInstanceDestroyMock,
+          updateData: autocompleteUpdateDataMock
         };
       }
     };
     const restore = mocker('Autocomplete', autocompleteMock);
+
     beforeEach(() => {
       autocompleteInitMock.mockClear();
       autocompleteInstanceDestroyMock.mockClear();
     });
 
+    afterAll(() => {
+      restore();
+    });
+
     test('calls Autocomplete', () => {
       mount(<Autocomplete />);
       expect(autocompleteInitMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls updateData when providing new data', () => {
+      const wrapper = shallow(<Autocomplete />);
+      expect(autocompleteInitMock).toHaveBeenCalledTimes(1);
+      wrapper.setProps({ options: { data: { Google: null } } });
+      expect(autocompleteUpdateDataMock).toHaveBeenCalledWith({ Google: null });
     });
   });
 });

--- a/test/Autocomplete.spec.js
+++ b/test/Autocomplete.spec.js
@@ -72,5 +72,12 @@ describe('<Autocomplete />', () => {
       wrapper.setProps({ options: { data: { Google: null } } });
       expect(autocompleteUpdateDataMock).toHaveBeenCalledWith({ Google: null });
     });
+
+    test('does not calls updateData when providing the same data', () => {
+      const wrapper = shallow(<Autocomplete options={{ data }} />);
+      expect(autocompleteInitMock).toHaveBeenCalledTimes(1);
+      wrapper.setProps({ options: { data } });
+      expect(autocompleteUpdateDataMock).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Description

Testing out #897 I've found that `Autocomplete` didn't update itself upon receiving new `data` using the `options` `prop`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've added a new `spec` ensuring that [`updateData` `method`](https://materializecss.com/autocomplete.html#methods) is called upon receiving new `data`.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
