### PR TITLE
fix: icon stories

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -23,7 +23,10 @@ class Card extends Component {
         })}
       >
         {title}
-        {reveal && { revealIcon }}
+        {reveal &&
+          cloneElement(revealIcon, {
+            className: 'right'
+          })}
       </span>
     );
   }

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -1,4 +1,4 @@
-import React, { Fragment, Component } from 'react';
+import React, { Fragment, Component, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from './Icon';
@@ -36,7 +36,10 @@ class Chip extends Component {
     let chipContent = (
       <Fragment>
         {children}
-        {close && { closeIcon }}
+        {close &&
+          cloneElement(closeIcon, {
+            className: 'close'
+          })}
       </Fragment>
     );
 

--- a/src/SideNavItem.js
+++ b/src/SideNavItem.js
@@ -29,7 +29,7 @@ class SideNavItem extends Component {
         {userView && user && <UserView {...user} />}
         {!userView && (
           <a className={cx(linkClasses)} href={href}>
-            {icon && <i className="material-icons">{icon}</i>}
+            {icon}
             {children}
           </a>
         )}

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
 
 import Select from '../src/Select';
+import Icon from '../src/Icon';
 
 const stories = storiesOf('Components|Select', module);
 
@@ -24,7 +26,7 @@ stories.add('Default', () => (
 ));
 
 stories.add('with Icon', () => (
-  <Select value="" icon="cloud">
+  <Select value="" icon={<Icon>{text('icon', 'cloud')}</Icon>}>
     <option value="" disabled>
       Choose your option
     </option>

--- a/stories/SideNav.stories.js
+++ b/stories/SideNav.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import SideNav from '../src/SideNav';
 import SideNavItem from '../src/SideNavItem';
 import Button from '../src/Button';
+import Icon from '../src/Icon';
 
 const stories = storiesOf('Javascript|SideNav', module);
 const reactMaterializeLogo = require('./react-materialize-logo.svg');
@@ -35,7 +36,7 @@ stories.add('Default', () => (
           email: 'jdandturk@gmail.com'
         }}
       />
-      <SideNavItem href="#!icon" icon="cloud">
+      <SideNavItem href="#!icon" icon={<Icon>cloud</Icon>}>
         First Link With Icon
       </SideNavItem>
       <SideNavItem href="#!second">Second Link</SideNavItem>

--- a/stories/Textarea.stories.js
+++ b/stories/Textarea.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { text, boolean, number, withKnobs } from '@storybook/addon-knobs';
 import Row from '../src/Row';
 import Textarea from '../src/Textarea';
+import Icon from '../src/Icon';
 
 const stories = storiesOf('Components|Textarea', module);
 stories.addDecorator(withKnobs);
@@ -52,7 +53,9 @@ stories.add('Label', () => (
   <Textarea label={text('label', 'Write something here...')} />
 ));
 
-stories.add('Icon', () => <Textarea icon={text('icon', 'mode_edit')} />);
+stories.add('Icon', () => (
+  <Textarea icon={<Icon>{text('icon', 'mode_edit')}</Icon>} />
+));
 
 stories.add(
   'Character Counter',

--- a/test/__snapshots__/Chip.spec.js.snap
+++ b/test/__snapshots__/Chip.spec.js.snap
@@ -9,7 +9,11 @@ exports[`<Chip /> accepts children 1`] = `
   >
     Child
   </p>
-  <Component />
+  <Icon
+    className="close"
+  >
+    close
+  </Icon>
 </div>
 `;
 

--- a/test/__snapshots__/SideNavItem.spec.js.snap
+++ b/test/__snapshots__/SideNavItem.spec.js.snap
@@ -23,10 +23,6 @@ exports[`<SideNavItem /> should render an icon when needed 1`] = `
   className=""
   href="#!"
 >
-  <i
-    className="material-icons"
-  >
-    car
-  </i>
+  car
 </a>
 `;


### PR DESCRIPTION
# Description

This __P.R__ is to address #908.
These bugs have been introduced in #890 .
I've fixed all the `stories` and also fixed some problem like missing `.right` `className` on `card` `reveal` and the `.close` `className` for `Chip`s

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
