### PR TITLE
feat: allow the use of left and right links in navbar

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment, Children } from 'react';
+import React, { Component, Fragment, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from './Icon';
@@ -27,6 +27,8 @@ class Navbar extends Component {
       extendWith,
       fixed,
       alignLinks,
+      rightLinks,
+      leftLinks,
       centerLogo,
       search,
       menuIcon,
@@ -35,7 +37,7 @@ class Navbar extends Component {
 
     const brandClasses = cx({
       'brand-logo': true,
-      center: centerLogo
+      center: centerLogo || leftLinks || rightLinks
     });
 
     const navCSS = cx({ 'nav-extended': extendWith }, className);
@@ -48,16 +50,13 @@ class Navbar extends Component {
 
     const sidenavLinks = sidenav
       ? sidenav
-      : Children.map(children, (link, index) => {
-          const clonedLink =
-            link && link.props && link.props.id
-              ? React.cloneElement(link, {
-                  ...link.props,
-                  id: `sidenav-${link.props.id}`
-                })
-              : link;
-          return <li key={index}>{clonedLink}</li>;
-        });
+      : [...leftLinks, ...rightLinks].map((link, index) => (
+          <li key={index}>
+            {cloneElement(link, {
+              id: `sidenav-link-${index}`
+            })}
+          </li>
+        ));
 
     let navbar = (
       <nav className={navCSS}>
@@ -67,13 +66,27 @@ class Navbar extends Component {
           ) : (
             <Fragment>
               {brand &&
-                React.cloneElement(brand, {
+                cloneElement(brand, {
                   className: cx(brand.props.className, brandClasses)
                 })}
               <a href="#!" data-target="mobile-nav" className="sidenav-trigger">
                 {menuIcon}
               </a>
-              <ul className={navMobileCSS}>{links}</ul>
+              {links && <ul className={navMobileCSS}>{links}</ul>}
+              {leftLinks && (
+                <ul className={cx('hide-on-med-and-down left')}>
+                  {leftLinks.map((link, index) => (
+                    <li key={`left-link-${index}`}>{link}</li>
+                  ))}
+                </ul>
+              )}
+              {rightLinks && (
+                <ul className={cx('hide-on-med-and-down right')}>
+                  {rightLinks.map((link, index) => (
+                    <li key={`right-link-${index}`}>{link}</li>
+                  ))}
+                </ul>
+              )}
             </Fragment>
           )}
         </div>
@@ -117,6 +130,8 @@ Navbar.propTypes = {
    * left makes the navbar links left aligned, right makes them right aligned
    */
   alignLinks: PropTypes.oneOf(['left', 'right']),
+  rightLinks: PropTypes.arrayOf(PropTypes.node),
+  leftLinks: PropTypes.arrayOf(PropTypes.node),
   /**
    * The logo will center itself on medium and down screens.
    * Specifying centerLogo as a prop the logo will always be centered
@@ -154,6 +169,8 @@ Navbar.propTypes = {
 };
 
 Navbar.defaultProps = {
+  leftLinks: [],
+  rightLinks: [],
   options: {
     edge: 'left',
     draggable: true,

--- a/stories/Navbar.stories.js
+++ b/stories/Navbar.stories.js
@@ -44,6 +44,26 @@ stories.add('Left Aligned Links', () => (
   </Navbar>
 ));
 
+stories.add('Left and Right Aligned Links', () => (
+  <Navbar
+    brand={
+      <a href="#" className="brand-logo right">
+        Logo
+      </a>
+    }
+    leftLinks={[
+      <NavItem onClick={() => console.log('test click')}>Sass</NavItem>,
+      <NavItem href="components.html">Components</NavItem>,
+      <NavItem href="components.html">Javascript</NavItem>
+    ]}
+    rightLinks={[
+      <NavItem onClick={() => console.log('test click')}>Less</NavItem>,
+      <NavItem href="components.html">Components</NavItem>,
+      <NavItem href="components.html">Typescript</NavItem>
+    ]}
+  />
+));
+
 stories.add('Center Logo', () => (
   <Navbar
     brand={

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -9,6 +9,7 @@ exports[`<Navbar /> adds a brand node 1`] = `
       I AM BRAND
     </span>
   }
+  leftLinks={Array []}
   menuIcon={
     <Icon>
       menu
@@ -27,6 +28,7 @@ exports[`<Navbar /> adds a brand node 1`] = `
       "preventScrolling": true,
     }
   }
+  rightLinks={Array []}
 >
   <nav
     className=""
@@ -35,7 +37,7 @@ exports[`<Navbar /> adds a brand node 1`] = `
       className="nav-wrapper"
     >
       <span
-        className="brando brand-logo"
+        className="brando brand-logo center"
       >
         I AM BRAND
       </span>
@@ -53,7 +55,10 @@ exports[`<Navbar /> adds a brand node 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down "
+        className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
       />
     </div>
   </nav>
@@ -82,7 +87,10 @@ exports[`<Navbar /> can be extended with custom elements 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down "
+        className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
       />
     </div>
     <div
@@ -140,7 +148,10 @@ exports[`<Navbar /> can be fixed 1`] = `
           </Icon>
         </a>
         <ul
-          className="hide-on-med-and-down "
+          className="hide-on-med-and-down left"
+        />
+        <ul
+          className="hide-on-med-and-down right"
         />
       </div>
     </nav>
@@ -176,7 +187,10 @@ exports[`<Navbar /> can center the brand logo 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down "
+        className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
       />
     </div>
   </nav>
@@ -226,31 +240,18 @@ exports[`<Navbar /> can have children with custom ids 1`] = `
           </span>
         </li>
       </ul>
+      <ul
+        className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
+      />
     </div>
   </nav>
   <ul
     className="sidenav "
     id="mobile-nav"
-  >
-    <li
-      key="0/.0"
-    >
-      <span
-        id="sidenav-custom-1"
-      >
-        Custom 1
-      </span>
-    </li>
-    <li
-      key="1/.1"
-    >
-      <span
-        id="sidenav-custom-2"
-      >
-        Custom 2
-      </span>
-    </li>
-  </ul>
+  />
 </Fragment>
 `;
 
@@ -263,7 +264,7 @@ exports[`<Navbar /> can have custom sidenav 1`] = `
       className="nav-wrapper"
     >
       <a
-        className="brand-logo"
+        className="brand-logo center"
         href="/"
       >
         Logo
@@ -278,7 +279,10 @@ exports[`<Navbar /> can have custom sidenav 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down"
+        className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
       />
     </div>
   </nav>
@@ -304,7 +308,7 @@ exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
       className="nav-wrapper"
     >
       <a
-        className="brand-logo"
+        className="brand-logo center"
         href="/"
       >
         Logo
@@ -320,6 +324,9 @@ exports[`<Navbar /> places brand on right if navbar is left aligned 1`] = `
       </a>
       <ul
         className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
       />
     </div>
   </nav>
@@ -339,7 +346,7 @@ exports[`<Navbar /> renders 1`] = `
       className="nav-wrapper"
     >
       <a
-        className="brand-logo"
+        className="brand-logo center"
         href="/"
       >
         Logo
@@ -375,30 +382,17 @@ exports[`<Navbar /> renders 1`] = `
           </a>
         </li>
       </ul>
+      <ul
+        className="hide-on-med-and-down left"
+      />
+      <ul
+        className="hide-on-med-and-down right"
+      />
     </div>
   </nav>
   <ul
     className="sidenav right"
     id="mobile-nav"
-  >
-    <li
-      key="0/.0"
-    >
-      <a
-        href="get-started.html"
-      >
-        Getting started
-      </a>
-    </li>
-    <li
-      key="1/.1"
-    >
-      <a
-        href="components.html"
-      >
-        Components
-      </a>
-    </li>
-  </ul>
+  />
 </Fragment>
 `;

--- a/test/__snapshots__/Navbar.spec.js.snap
+++ b/test/__snapshots__/Navbar.spec.js.snap
@@ -187,6 +187,73 @@ exports[`<Navbar /> can center the brand logo 1`] = `
 </Fragment>
 `;
 
+exports[`<Navbar /> can have children with custom ids 1`] = `
+<Fragment>
+  <nav
+    className=""
+  >
+    <div
+      className="nav-wrapper"
+    >
+      <a
+        className="sidenav-trigger"
+        data-target="mobile-nav"
+        href="#!"
+      >
+        <Icon>
+          menu
+        </Icon>
+      </a>
+      <ul
+        className="hide-on-med-and-down "
+      >
+        <li
+          key="0/.0"
+        >
+          <span
+            id="custom-1"
+          >
+            Custom 1
+          </span>
+        </li>
+        <li
+          key="1/.1"
+        >
+          <span
+            id="custom-2"
+          >
+            Custom 2
+          </span>
+        </li>
+      </ul>
+    </div>
+  </nav>
+  <ul
+    className="sidenav "
+    id="mobile-nav"
+  >
+    <li
+      key="0/.0"
+    >
+      <span
+        id="sidenav-custom-1"
+      >
+        Custom 1
+      </span>
+    </li>
+    <li
+      key="1/.1"
+    >
+      <span
+        id="sidenav-custom-2"
+      >
+        Custom 2
+      </span>
+    </li>
+  </ul>
+</Fragment>
+`;
+
 exports[`<Navbar /> can have custom sidenav 1`] = `
 <Fragment>
   <nav
@@ -211,7 +278,7 @@ exports[`<Navbar /> can have custom sidenav 1`] = `
         </Icon>
       </a>
       <ul
-        className="hide-on-med-and-down left"
+        className="hide-on-med-and-down"
       />
     </div>
   </nav>
@@ -331,114 +398,6 @@ exports[`<Navbar /> renders 1`] = `
       >
         Components
       </a>
-    </li>
-  </ul>
-</Fragment>
-`;
-
-exports[`<Navbar /> can have custom sidenav 1`] = `
-<Fragment>
-  <nav
-    className=""
-  >
-    <div
-      className="nav-wrapper"
-    >
-      <a
-        className="brand-logo"
-        href="/"
-      >
-        Logo
-      </a>
-      <a
-        className="sidenav-trigger"
-        data-target="mobile-nav"
-        href="#!"
-      >
-        <Icon>
-          menu
-        </Icon>
-      </a>
-      <ul
-        className="hide-on-med-and-down left"
-      />
-    </div>
-  </nav>
-  <ul
-    className="sidenav left"
-    id="mobile-nav"
-  >
-    <li
-      className="custom-node"
-    >
-      Custom node!
-    </li>
-  </ul>
-</Fragment>
-`;
-
-exports[`<Navbar /> can have children with custom ids 1`] = `
-<Fragment>
-  <nav
-    className=""
-  >
-    <div
-      className="nav-wrapper"
-    >
-      <a
-        className="sidenav-trigger"
-        data-target="mobile-nav"
-        href="#!"
-      >
-        <Icon>
-          menu
-        </Icon>
-      </a>
-      <ul
-        className="hide-on-med-and-down "
-      >
-        <li
-          key="0/.0"
-        >
-          <span
-            id="custom-1"
-          >
-            Custom 1
-          </span>
-        </li>
-        <li
-          key="1/.1"
-        >
-          <span
-            id="custom-2"
-          >
-            Custom 2
-          </span>
-        </li>
-      </ul>
-    </div>
-  </nav>
-  <ul
-    className="sidenav "
-    id="mobile-nav"
-  >
-    <li
-      key="0/.0"
-    >
-      <span
-        id="sidenav-custom-1"
-      >
-        Custom 1
-      </span>
-    </li>
-    <li
-      key="1/.1"
-    >
-      <span
-        id="sidenav-custom-2"
-      >
-        Custom 2
-      </span>
     </li>
   </ul>
 </Fragment>


### PR DESCRIPTION
# Description

As shown here
[![Edit admiring-curie-n7nj1](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/admiring-curie-n7nj1?fontsize=14)
It's possible to align some links on the left and others on the right of the [`navbar`](https://materializecss.com/navbar.html).
As of now, it's not possible to reproduce this behavior with `React Materialize`.

This __P.R__ is to address this problem:
- Added `rightLinks` `prop`
- Added `leftLinks` `prop`

By default all the links provided both as `rightLinks` and `leftLinks` are also visible in the `SideNav`.
However the `SideNav` is customizable thanks to #878 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Updated `snapshots` and added a new `story`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
