### PR TITLE
fix: remove tooltipOptions from DOM

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -48,6 +48,8 @@ class Button extends Component {
       ...other
     } = this.props;
 
+    delete other.tooltipOptions;
+
     let C = node;
     let classes = {
       btn: true,

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -138,14 +138,14 @@ stories.add('Tooltip', () => {
     >
       <Button
         className="col l2 offset-l1 offset-s4 s4"
-        waves="ligth"
+        waves="light"
         tooltip={tooltip}
       >
         BOTTOM
       </Button>
       <Button
         className="col l2 offset-l1 offset-s4 s4"
-        waves="ligth"
+        waves="light"
         tooltip={tooltip}
         tooltipOptions={{
           position: 'top'
@@ -155,7 +155,7 @@ stories.add('Tooltip', () => {
       </Button>
       <Button
         className="col l2 offset-l1 offset-s4 s4"
-        waves="ligth"
+        waves="light"
         tooltip={tooltip}
         tooltipOptions={{
           position: 'left'
@@ -165,7 +165,7 @@ stories.add('Tooltip', () => {
       </Button>
       <Button
         className="col l2 offset-l1 offset-s4 s4"
-        waves="ligth"
+        waves="light"
         tooltip={tooltip}
         tooltipOptions={{
           position: 'right'


### PR DESCRIPTION
# Description

Apparently, `tooltipOptions` was erroneously added to the DOM.
This __P.R__ fixes this.
Also fixes some button `stories which used the wrong value of `ligth` as `waves`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Nothing to test here.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
