### PR TITLE
Range: Convert to stateless and use hooks

### DIFF
--- a/src/Range.js
+++ b/src/Range.js
@@ -1,31 +1,26 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-class Range extends React.Component {
-  componentDidMount() {
-    if (typeof M !== 'undefined') {
-      this.instance = M.Range.init(this._range);
-    }
-  }
+const Range = props => {
+  const instance = useRef(null);
+  const rangeRef = useRef(null);
 
-  componentWillUnmount() {
-    this.instance && this.instance.destroy();
-  }
+  useEffect(() => {
+    instance.current = M.Range.init(rangeRef.current);
 
-  render() {
-    return (
-      <p className="range-field">
-        <input
-          type="range"
-          ref={el => {
-            this._range = el;
-          }}
-          {...this.props}
-        />
-      </p>
-    );
-  }
-}
+    return () => {
+      if (instance.current) {
+        instance.current.destroy();
+      }
+    };
+  }, [rangeRef.current, instance.current]);
+
+  return (
+    <p className="range-field">
+      <input type="range" ref={rangeRef} {...props} />
+    </p>
+  );
+};
 
 Range.propTypes = {
   min: PropTypes.string.isRequired,

--- a/test/Range.spec.js
+++ b/test/Range.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import Range from '../src/Range';
 import mocker from './helper/new-mocker';
 
@@ -8,10 +8,10 @@ describe('<Range />', () => {
   const mockInit = jest.fn();
 
   const rangeMock = { init: mockInit };
-  const restore = mocker('Range', rangeMock);
+  mocker('Range', rangeMock);
 
   test('renders', () => {
-    wrapper = shallow(<Range min="10" max="99" />);
+    wrapper = mount(<Range min="10" max="99" />);
     expect(wrapper).toMatchSnapshot();
     expect(mockInit).toHaveBeenCalledTimes(1);
   });

--- a/test/__snapshots__/Range.spec.js.snap
+++ b/test/__snapshots__/Range.spec.js.snap
@@ -1,13 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Range /> renders 1`] = `
-<p
-  className="range-field"
+<Range
+  max="99"
+  min="10"
 >
-  <input
-    max="99"
-    min="10"
-    type="range"
-  />
-</p>
+  <p
+    className="range-field"
+  >
+    <input
+      max="99"
+      min="10"
+      type="range"
+    />
+  </p>
+</Range>
 `;


### PR DESCRIPTION
Part of #928

Use hooks instead of class instances.

Details below 👇 