### PR TITLE
Parallax: convert to stateless and use hooks

### DIFF
--- a/src/Parallax.js
+++ b/src/Parallax.js
@@ -11,7 +11,7 @@ const Parallax = ({ children, className, image, options, ...props }) => {
     return () => {
       instance && instance.destroy();
     };
-  }, [_parallax]);
+  }, [_parallax, options]);
 
   return (
     <div className={cx('parallax-container', className)} {...props}>

--- a/src/Parallax.js
+++ b/src/Parallax.js
@@ -6,18 +6,12 @@ const Parallax = ({ children, className, image, options, ...props }) => {
   const _parallax = useRef(null);
 
   useEffect(() => {
-    let instance = null;
-
-    if (_parallax.current) {
-      if (typeof M !== 'undefined') {
-        instance = M.Parallax.init(_parallax.current, options);
-      }
-    }
+    const instance = M.Parallax.init(_parallax.current, options);
 
     return () => {
       instance && instance.destroy();
     };
-  }, [_parallax.current]);
+  }, [_parallax]);
 
   return (
     <div className={cx('parallax-container', className)} {...props}>

--- a/src/Parallax.js
+++ b/src/Parallax.js
@@ -3,24 +3,26 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 const Parallax = ({ children, className, image, options, ...props }) => {
-  const parallaxContainer = useRef(null);
+  const _parallax = useRef(null);
 
   useEffect(() => {
     let instance = null;
 
-    if (parallaxContainer.current) {
+    if (_parallax.current) {
       if (typeof M !== 'undefined') {
-        instance = M.Parallax.init(parallaxContainer.current, options);
+        instance = M.Parallax.init(_parallax.current, options);
       }
     }
 
-    return instance && instance.destroy();
-  }, [parallaxContainer]);
+    return () => {
+      instance && instance.destroy();
+    };
+  }, [_parallax.current]);
 
   return (
     <div className={cx('parallax-container', className)} {...props}>
       {children}
-      <div className="parallax" ref={parallaxContainer}>
+      <div className="parallax" ref={_parallax}>
         {image}
       </div>
     </div>

--- a/src/Parallax.js
+++ b/src/Parallax.js
@@ -1,39 +1,31 @@
-import React, { Component } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-class Parallax extends Component {
-  componentDidMount() {
-    if (typeof M !== 'undefined') {
-      const { options } = this.props;
-      this.instance = M.Parallax.init(this._parallax, options);
+const Parallax = ({ children, className, image, options, ...props }) => {
+  const parallaxContainer = useRef(null);
+
+  useEffect(() => {
+    let instance = null;
+
+    if (parallaxContainer.current) {
+      if (typeof M !== 'undefined') {
+        instance = M.Parallax.init(parallaxContainer.current, options);
+      }
     }
-  }
 
-  componentWillUnmount() {
-    this.instance && this.instance.destroy();
-  }
+    return instance && instance.destroy();
+  }, [parallaxContainer]);
 
-  render() {
-    const { children, className, image, ...props } = this.props;
-
-    delete props.options;
-
-    return (
-      <div className={cx('parallax-container', className)} {...props}>
-        {children}
-        <div
-          className="parallax"
-          ref={div => {
-            this._parallax = div;
-          }}
-        >
-          {image}
-        </div>
+  return (
+    <div className={cx('parallax-container', className)} {...props}>
+      {children}
+      <div className="parallax" ref={parallaxContainer}>
+        {image}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 Parallax.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
# Description

Part of #928 

# How Has This Been Tested?

No need to change `specs` here, as the current one already uses `mount`.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
