### PR TITLE
Carousel: refactor to function component and use hooks

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -1,28 +1,28 @@
-import React from 'react';
+import React, { Children, cloneElement, useEffect, useRef } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
-class Carousel extends React.Component {
-  constructor(props) {
-    super(props);
+const Carousel = ({
+  children,
+  className,
+  fixedItem,
+  images,
+  centerImages,
+  options,
+  ...props
+}) => {
+  const _carousel = useRef(null);
+  const elemsToRender = children || images || [];
 
-    this.renderFixedItem = this.renderFixedItem.bind(this);
-  }
+  useEffect(() => {
+    const instance = M.Carousel.init(_carousel.current, options);
 
-  componentDidMount() {
-    const { options } = this.props;
-    if (options && typeof M !== 'undefined') {
-      this.instance = M.Carousel.init(this._carousel, options);
-    }
-  }
+    return () => {
+      instance && instance.destroy();
+    };
+  }, [_carousel]);
 
-  componentWillUnmount() {
-    if (this.instance) {
-      this.instance.destroy();
-    }
-  }
-
-  renderItems(child, centerImages) {
+  const renderItems = child => {
     if (typeof child === 'string') {
       return (
         <a
@@ -35,51 +35,32 @@ class Carousel extends React.Component {
       );
     }
 
-    return React.cloneElement(child, {
+    return cloneElement(child, {
       className: cx('carousel-item', child.props.className, {
         'valign-wrapper': centerImages
       })
     });
-  }
+  };
 
-  renderFixedItem(fixedItem) {
-    return <div className="carousel-fixed-item center">{fixedItem}</div>;
-  }
-
-  render() {
-    const {
-      children,
-      className,
-      carouselId,
-      fixedItem,
-      images,
-      centerImages,
-      options
-    } = this.props;
-    const elemsToRender = children || images || [];
-
-    return (
-      elemsToRender && (
-        <div
-          id={carouselId}
-          ref={el => {
-            this._carousel = el;
-          }}
-          className={cx(
-            'carousel',
-            { 'carousel-slider': options.fullWidth },
-            className
-          )}
-        >
-          {fixedItem && this.renderFixedItem(fixedItem)}
-          {React.Children.map(elemsToRender, child =>
-            this.renderItems(child, centerImages)
-          )}
-        </div>
-      )
-    );
-  }
-}
+  return (
+    elemsToRender && (
+      <div
+        ref={_carousel}
+        className={cx(
+          'carousel',
+          { 'carousel-slider': options.fullWidth },
+          className
+        )}
+        {...props}
+      >
+        {Children.map(elemsToRender, renderItems)}
+        {fixedItem && (
+          <div className="carousel-fixed-item center">{fixedItem}</div>
+        )}
+      </div>
+    )
+  );
+};
 
 Carousel.propTypes = {
   /*

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -20,7 +20,7 @@ const Carousel = ({
     return () => {
       instance && instance.destroy();
     };
-  }, [_carousel]);
+  }, [_carousel, options]);
 
   const renderItems = child => {
     if (typeof child === 'string') {

--- a/stories/Carousel.stories.js
+++ b/stories/Carousel.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Carousel from '../src/Carousel';
+import Button from '../src/Button';
 
 const stories = storiesOf('Javascript|Carousel', module);
 
@@ -47,6 +48,36 @@ stories.add('html content', () => (
       indicators: true
     }}
     className="white-text center"
+  >
+    <div className="red">
+      <h2>First Panel</h2>
+      <p>This is your first panel</p>
+    </div>
+    <div className="amber">
+      <h2>Second Panel</h2>
+      <p>This is your second panel</p>
+    </div>
+    <div className="green">
+      <h2>Third Panel</h2>
+      <p>This is your third panel</p>
+    </div>
+    <div className="blue">
+      <h2>Fourth Panel</h2>
+      <p>This is your fourth panel</p>
+    </div>
+  </Carousel>
+));
+
+stories.add('fixed item', () => (
+  <Carousel
+    options={{
+      fullWidth: true,
+      indicators: true
+    }}
+    className="white-text center"
+    fixedItem={
+      <Button className="white grey-text darken-text-2">BUTTON</Button>
+    }
   >
     <div className="red">
       <h2>First Panel</h2>

--- a/test/Carousel.spec.js
+++ b/test/Carousel.spec.js
@@ -47,7 +47,7 @@ describe('<Carousel />', () => {
   });
 
   test('accepts external `id` value', () => {
-    wrapper = shallow(<Carousel images={images} carouselId="ID" />);
+    wrapper = shallow(<Carousel images={images} id="ID" />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -75,7 +75,7 @@ describe('<Carousel />', () => {
     });
 
     test('uses default options if none are given', () => {
-      wrapper = shallow(<Carousel />);
+      wrapper = mount(<Carousel />);
 
       expect(carouselInitMock).toHaveBeenCalledWith({
         duration: 200,
@@ -91,7 +91,7 @@ describe('<Carousel />', () => {
     });
 
     test('handles full width sliders', () => {
-      wrapper = shallow(
+      wrapper = mount(
         <Carousel images={images} options={{ fullWidth: true }} />
       );
       expect(wrapper).toMatchSnapshot();
@@ -100,10 +100,11 @@ describe('<Carousel />', () => {
 
     test('more options', () => {
       const options = { padding: 12, fullWidth: true, indicators: false };
-      wrapper = shallow(<Carousel images={images} options={options} />);
+      wrapper = mount(<Carousel images={images} options={options} />);
       expect(carouselInitMock).toHaveBeenCalledWith(options);
     });
   });
+
   describe('undefined M', () => {
     let __M;
     beforeEach(() => {
@@ -114,7 +115,6 @@ describe('<Carousel />', () => {
       global.M = __M;
     });
     test('doesnt throw without M', () => {
-      const tooltip = {};
       expect(() =>
         mount(<Carousel options={{ fullWidth: true }} />)
       ).not.toThrow();

--- a/test/Carousel.spec.js
+++ b/test/Carousel.spec.js
@@ -104,20 +104,4 @@ describe('<Carousel />', () => {
       expect(carouselInitMock).toHaveBeenCalledWith(options);
     });
   });
-
-  describe('undefined M', () => {
-    let __M;
-    beforeEach(() => {
-      __M = global.M;
-      global.M = undefined;
-    });
-    afterEach(() => {
-      global.M = __M;
-    });
-    test('doesnt throw without M', () => {
-      expect(() =>
-        mount(<Carousel options={{ fullWidth: true }} />)
-      ).not.toThrow();
-    });
-  });
 });

--- a/test/__snapshots__/Carousel.spec.js.snap
+++ b/test/__snapshots__/Carousel.spec.js.snap
@@ -106,46 +106,62 @@ exports[`<Carousel /> handles content slides 1`] = `
 `;
 
 exports[`<Carousel /> initialises handles full width sliders 1`] = `
-<div
-  className="carousel carousel-slider"
+<Carousel
+  images={
+    Array [
+      "https://lorempixel.com/250/250/nature/1",
+      "https://lorempixel.com/250/250/nature/2",
+      "https://lorempixel.com/250/250/nature/3",
+      "https://lorempixel.com/250/250/nature/4",
+    ]
+  }
+  options={
+    Object {
+      "fullWidth": true,
+    }
+  }
 >
-  <a
-    className="carousel-item"
-    key=".0"
+  <div
+    className="carousel carousel-slider"
   >
-    <img
-      alt=""
-      src="https://lorempixel.com/250/250/nature/1"
-    />
-  </a>
-  <a
-    className="carousel-item"
-    key=".1"
-  >
-    <img
-      alt=""
-      src="https://lorempixel.com/250/250/nature/2"
-    />
-  </a>
-  <a
-    className="carousel-item"
-    key=".2"
-  >
-    <img
-      alt=""
-      src="https://lorempixel.com/250/250/nature/3"
-    />
-  </a>
-  <a
-    className="carousel-item"
-    key=".3"
-  >
-    <img
-      alt=""
-      src="https://lorempixel.com/250/250/nature/4"
-    />
-  </a>
-</div>
+    <a
+      className="carousel-item"
+      key=".0"
+    >
+      <img
+        alt=""
+        src="https://lorempixel.com/250/250/nature/1"
+      />
+    </a>
+    <a
+      className="carousel-item"
+      key=".1"
+    >
+      <img
+        alt=""
+        src="https://lorempixel.com/250/250/nature/2"
+      />
+    </a>
+    <a
+      className="carousel-item"
+      key=".2"
+    >
+      <img
+        alt=""
+        src="https://lorempixel.com/250/250/nature/3"
+      />
+    </a>
+    <a
+      className="carousel-item"
+      key=".3"
+    >
+      <img
+        alt=""
+        src="https://lorempixel.com/250/250/nature/4"
+      />
+    </a>
+  </div>
+</Carousel>
 `;
 
 exports[`<Carousel /> renders 1`] = `
@@ -238,13 +254,6 @@ exports[`<Carousel /> renders fixed items 1`] = `
 <div
   className="carousel"
 >
-  <div
-    className="carousel-fixed-item center"
-  >
-    <span>
-      Do you rock!?
-    </span>
-  </div>
   <a
     className="carousel-item"
     key=".0"
@@ -281,5 +290,12 @@ exports[`<Carousel /> renders fixed items 1`] = `
       src="https://lorempixel.com/250/250/nature/4"
     />
   </a>
+  <div
+    className="carousel-fixed-item center"
+  >
+    <span>
+      Do you rock!?
+    </span>
+  </div>
 </div>
 `;


### PR DESCRIPTION
# Description

Part of #928 

# How Has This Been Tested?

The only `spec` failing is this one:
```js
  describe('undefined M', () => {
    let __M;
    beforeEach(() => {
      __M = global.M;
      global.M = undefined;
    });
    afterEach(() => {
      global.M = __M;
    });
    test('doesnt throw without M', () => {
      expect(() =>
        mount(<Carousel options={{ fullWidth: true }} />)
      ).not.toThrow();
    });
  });
```

That's because, as also [requested here](https://github.com/react-materialize/react-materialize/pull/935#discussion_r349933957), we have removed the check for `typeof M !== 'undefined'.

Let me know if you want to remove the `spec` or reintroduce the check.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
