### PR TITLE
TimePicker: refactor to use hooks

### DIFF
--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -15,7 +15,7 @@ const TimePicker = ({ onChange, options, ...props }) => {
     return () => {
       instance && instance.destroy();
     };
-  }, [document.getElementById(id)]);
+  }, [id, onChange, options]);
 
   return <TextInput id={id} inputClassName="timepicker" {...props} />;
 };

--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -1,39 +1,24 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import TextInput from './TextInput';
 import idgen from './idgen';
 
-class TimePicker extends React.Component {
-  constructor(props) {
-    super(props);
+const TimePicker = ({ onChange, options, ...props }) => {
+  const id = useMemo(() => props.id, [props.id]);
 
-    this.id = props.id || `timepicker${idgen()}`;
-  }
+  useEffect(() => {
+    const instance = M.Timepicker.init(document.getElementById(id), {
+      ...options,
+      onSelect: onChange
+    });
 
-  componentDidMount() {
-    if (typeof M !== 'undefined') {
-      const { onChange } = this.props;
-      const elem = document.getElementById(this.id);
-      const options = onChange
-        ? { ...this.props.options, onSelect: onChange }
-        : this.props.options;
+    return () => {
+      instance && instance.destroy();
+    };
+  }, [document.getElementById(id)]);
 
-      this.instance = M.Timepicker.init(elem, options);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.instance) {
-      this.instance.destroy();
-    }
-  }
-
-  render() {
-    return (
-      <TextInput id={this.id} inputClassName="timepicker" {...this.props} />
-    );
-  }
-}
+  return <TextInput id={id} inputClassName="timepicker" {...props} />;
+};
 
 TimePicker.propTypes = {
   /**
@@ -127,6 +112,7 @@ TimePicker.propTypes = {
 };
 
 TimePicker.defaultProps = {
+  id: `timepicker${idgen()}`,
   options: {
     duration: 350,
     container: null,

--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -132,7 +132,8 @@ TimePicker.defaultProps = {
     onCloseStart: null,
     onCloseEnd: null,
     onSelect: null
-  }
+  },
+  onChange: null
 };
 
 export default TimePicker;

--- a/test/__snapshots__/TimePicker.spec.js.snap
+++ b/test/__snapshots__/TimePicker.spec.js.snap
@@ -4,28 +4,6 @@ exports[`<TimePicker /> accepts external \`id\` value 1`] = `
 <TextInput
   id="ID"
   inputClassName="timepicker"
-  options={
-    Object {
-      "autoClose": false,
-      "container": null,
-      "defaultTime": "now",
-      "duration": 350,
-      "fromNow": 0,
-      "i18n": Object {
-        "cancel": "Cancel",
-        "clear": "Clear",
-        "done": "Ok",
-      },
-      "onCloseEnd": null,
-      "onCloseStart": null,
-      "onOpenEnd": null,
-      "onOpenStart": null,
-      "onSelect": null,
-      "showClearBtn": false,
-      "twelveHour": true,
-      "vibrate": true,
-    }
-  }
 />
 `;
 
@@ -33,28 +11,6 @@ exports[`<TimePicker /> renders 1`] = `
 <TextInput
   id="timepickermockId"
   inputClassName="timepicker"
-  options={
-    Object {
-      "autoClose": false,
-      "container": null,
-      "defaultTime": "now",
-      "duration": 350,
-      "fromNow": 0,
-      "i18n": Object {
-        "cancel": "Cancel",
-        "clear": "Clear",
-        "done": "Ok",
-      },
-      "onCloseEnd": null,
-      "onCloseStart": null,
-      "onOpenEnd": null,
-      "onOpenStart": null,
-      "onSelect": null,
-      "showClearBtn": false,
-      "twelveHour": true,
-      "vibrate": true,
-    }
-  }
 />
 `;
 
@@ -63,27 +19,5 @@ exports[`<TimePicker /> renders with a label 1`] = `
   id="timepickermockId"
   inputClassName="timepicker"
   label="TimePicker label"
-  options={
-    Object {
-      "autoClose": false,
-      "container": null,
-      "defaultTime": "now",
-      "duration": 350,
-      "fromNow": 0,
-      "i18n": Object {
-        "cancel": "Cancel",
-        "clear": "Clear",
-        "done": "Ok",
-      },
-      "onCloseEnd": null,
-      "onCloseStart": null,
-      "onOpenEnd": null,
-      "onOpenStart": null,
-      "onSelect": null,
-      "showClearBtn": false,
-      "twelveHour": true,
-      "vibrate": true,
-    }
-  }
 />
 `;


### PR DESCRIPTION
# Description

Part of #928 

# How Has This Been Tested?

Updated `specs`.
As in #931 we are going to keep the `id` until we refactor `TextInput` to use `useRef` `hook`.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
