### PR TITLE
Merge pull request #950 from CloudPower97/refactor/checkbox

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,69 +1,52 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import idgen from './idgen';
 
-class Checkbox extends Component {
-  constructor(props) {
-    super(props);
-  }
+const Checkbox = ({
+  id,
+  className,
+  indeterminate,
+  filledIn,
+  label,
+  onChange,
+  ...props
+}) => {
+  const [checked, setChecked] = useState(props.checked);
+  const _input = useRef(null);
 
-  componentDidMount() {
-    const { indeterminate } = this.props;
-
-    if (this._input && indeterminate) {
-      this._input.indeterminate = indeterminate;
-      this._input.checked = false;
+  useEffect(() => {
+    if (_input.current && indeterminate) {
+      _input.current.indeterminate = indeterminate;
+      _input.current.checked = false;
     }
-  }
+  }, [indeterminate]);
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.indeterminate !== this.props.indeterminate) {
-      this._input.indeterminate = this.props.indeterminate;
-    }
-  }
+  delete props.checked;
 
-  render() {
-    const {
-      id,
-      className,
-      indeterminate,
-      filledIn,
-      disabled,
-      onChange,
-      checked,
-      value,
-      label
-    } = this.props;
-
-    let computedId = id || idgen();
-
-    if (indeterminate) {
-      computedId = `indeterminate-checkbox-${idgen()}`;
-    }
-
-    return (
-      <label htmlFor={computedId}>
-        <input
-          id={computedId}
-          className={cx(
-            {
-              'filled-in': filledIn
-            },
-            className
-          )}
-          disabled={disabled}
-          onChange={onChange}
-          type="checkbox"
-          checked={checked}
-          value={value}
-          ref={input => (this._input = input)}
-        />
-        <span>{label}</span>
-      </label>
-    );
-  }
-}
+  return (
+    <label htmlFor={id}>
+      <input
+        id={id}
+        className={cx(
+          {
+            'filled-in': filledIn
+          },
+          className
+        )}
+        type="checkbox"
+        ref={_input}
+        checked={checked}
+        onChange={e => {
+          setChecked(prevChecked => !prevChecked);
+          onChange && onChange(e);
+        }}
+        {...props}
+      />
+      <span>{label}</span>
+    </label>
+  );
+};
 
 Checkbox.propTypes = {
   className: PropTypes.string,
@@ -100,6 +83,10 @@ Checkbox.propTypes = {
    * A Boolean attribute indicating whether or not this checkbox is checked
    */
   checked: PropTypes.bool
+};
+
+Checkbox.defaultProps = {
+  id: `checkbox_${idgen()}`
 };
 
 export default Checkbox;

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -25,6 +25,7 @@ const Checkbox = ({
 
   useEffect(() => {
     setChecked(props.checked);
+    _input.current.checked = props.checked;
   }, [props.checked]);
 
   return (

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -16,17 +16,21 @@ const Checkbox = ({
   const _input = useRef(null);
 
   useEffect(() => {
-    if (_input.current && indeterminate) {
+    if (_input.current) {
       _input.current.indeterminate = indeterminate;
       _input.current.checked = false;
+      setChecked(false);
     }
   }, [indeterminate]);
 
-  delete props.checked;
+  useEffect(() => {
+    setChecked(props.checked);
+  }, [props.checked]);
 
   return (
     <label htmlFor={id}>
       <input
+        {...props}
         id={id}
         className={cx(
           {
@@ -41,7 +45,6 @@ const Checkbox = ({
           setChecked(prevChecked => !prevChecked);
           onChange && onChange(e);
         }}
-        {...props}
       />
       <span>{label}</span>
     </label>

--- a/test/Checkbox.spec.js
+++ b/test/Checkbox.spec.js
@@ -13,8 +13,8 @@ describe('<Checkbox />', () => {
   });
 
   test('renders', () => {
-    wrapper = shallow(<Checkbox value="red" label="red" />);
-    expect(idgen).toHaveBeenCalledTimes(1);
+    wrapper = mount(<Checkbox value="red" label="red" />);
+    expect(wrapper.prop('id')).toBe(`checkbox_${idgen()}`);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/test/Checkbox.spec.js
+++ b/test/Checkbox.spec.js
@@ -1,20 +1,12 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import Checkbox from '../src/Checkbox';
-import idgen from '../src/idgen';
-
-jest.mock('../src/idgen');
 
 describe('<Checkbox />', () => {
   let wrapper;
 
-  beforeEach(() => {
-    idgen.mockClear();
-  });
-
   test('renders', () => {
-    wrapper = mount(<Checkbox value="red" label="red" />);
-    expect(wrapper.prop('id')).toBe(`checkbox_${idgen()}`);
+    wrapper = shallow(<Checkbox value="red" label="red" />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -30,7 +22,6 @@ describe('<Checkbox />', () => {
 
   test('with id', () => {
     wrapper = shallow(<Checkbox value="red" label="red" id="test" />);
-    expect(idgen).not.toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/test/__snapshots__/Checkbox.spec.js.snap
+++ b/test/__snapshots__/Checkbox.spec.js.snap
@@ -43,26 +43,20 @@ exports[`<Checkbox /> filled-in 1`] = `
 `;
 
 exports[`<Checkbox /> renders 1`] = `
-<Checkbox
-  id="checkbox_mockId"
-  label="red"
-  value="red"
+<label
+  htmlFor="checkbox_mockId"
 >
-  <label
-    htmlFor="checkbox_mockId"
-  >
-    <input
-      className=""
-      id="checkbox_mockId"
-      onChange={[Function]}
-      type="checkbox"
-      value="red"
-    />
-    <span>
-      red
-    </span>
-  </label>
-</Checkbox>
+  <input
+    className=""
+    id="checkbox_mockId"
+    onChange={[Function]}
+    type="checkbox"
+    value="red"
+  />
+  <span>
+    red
+  </span>
+</label>
 `;
 
 exports[`<Checkbox /> renders disabled 1`] = `

--- a/test/__snapshots__/Checkbox.spec.js.snap
+++ b/test/__snapshots__/Checkbox.spec.js.snap
@@ -4,15 +4,17 @@ exports[`<Checkbox /> does not overwrite materialize-css classnames 1`] = `
 <Checkbox
   className="my-class"
   filledIn={true}
+  id="checkbox_mockId"
   label="red"
   value="red"
 >
   <label
-    htmlFor="mockId"
+    htmlFor="checkbox_mockId"
   >
     <input
       className="filled-in my-class"
-      id="mockId"
+      id="checkbox_mockId"
+      onChange={[Function]}
       type="checkbox"
       value="red"
     />
@@ -25,11 +27,12 @@ exports[`<Checkbox /> does not overwrite materialize-css classnames 1`] = `
 
 exports[`<Checkbox /> filled-in 1`] = `
 <label
-  htmlFor="mockId"
+  htmlFor="checkbox_mockId"
 >
   <input
     className="filled-in"
-    id="mockId"
+    id="checkbox_mockId"
+    onChange={[Function]}
     type="checkbox"
     value="red"
   />
@@ -40,29 +43,37 @@ exports[`<Checkbox /> filled-in 1`] = `
 `;
 
 exports[`<Checkbox /> renders 1`] = `
-<label
-  htmlFor="mockId"
+<Checkbox
+  id="checkbox_mockId"
+  label="red"
+  value="red"
 >
-  <input
-    className=""
-    id="mockId"
-    type="checkbox"
-    value="red"
-  />
-  <span>
-    red
-  </span>
-</label>
+  <label
+    htmlFor="checkbox_mockId"
+  >
+    <input
+      className=""
+      id="checkbox_mockId"
+      onChange={[Function]}
+      type="checkbox"
+      value="red"
+    />
+    <span>
+      red
+    </span>
+  </label>
+</Checkbox>
 `;
 
 exports[`<Checkbox /> renders disabled 1`] = `
 <label
-  htmlFor="mockId"
+  htmlFor="checkbox_mockId"
 >
   <input
     className=""
     disabled={true}
-    id="mockId"
+    id="checkbox_mockId"
+    onChange={[Function]}
     type="checkbox"
     value="red"
   />
@@ -79,6 +90,7 @@ exports[`<Checkbox /> with id 1`] = `
   <input
     className=""
     id="test"
+    onChange={[Function]}
     type="checkbox"
     value="red"
   />


### PR DESCRIPTION
# Description

Part of #928

Also fixed a bug which prevented the `checkbox` in a `checked` state if initially `checked`.
To do so, I used `useState` to track changes of `checked`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just a little note here, I moved the `idgen` call to a `defaultProps`.
For some reason it seems that this is failing:
```js
    expect(idgen).toHaveBeenCalledTimes(1);
```

But having a look at the `snapshots` everything looks just fine.
I decided to the test the effect of calling `idgen` instead of checking if `idgen` was called doing so:
```js
    expect(wrapper.prop('id')).toBe(`checkbox_${idgen()}`);
```

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
