### PR TITLE
Autocomplete: use hooks

### DIFF
--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -1,111 +1,66 @@
-/* eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }] */
-import React, { Component } from 'react';
+import React, { cloneElement, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import constants from './constants';
 import idgen from './idgen';
 
-class Autocomplete extends Component {
-  constructor(props) {
-    super(props);
+const Autocomplete = ({
+  id,
+  className,
+  title,
+  icon,
+  s,
+  m,
+  l,
+  xl,
+  offset,
+  placeholder,
+  // these are mentioned here only to prevent from getting into ...props
+  value,
+  onChange,
+  options,
+  ...props
+}) => {
+  const _autocomplete = useRef(null);
+  const sizes = { s, m, l, xl };
+  let classes = {
+    col: true
+  };
+  constants.SIZES.forEach(size => {
+    classes[size + sizes[size]] = sizes[size];
+  });
 
-    this.state = {
-      value: props.value || '',
-      itemSelected: false
+  const renderIcon = icon => {
+    return cloneElement(icon, { className: 'prefix' });
+  };
+
+  useEffect(() => {
+    const instance = M.Autocomplete.init(_autocomplete.current, options);
+
+    return () => {
+      instance && instance.destroy();
     };
+  }, [options]);
 
-    this.renderIcon = this.renderIcon.bind(this);
-    this._onChange = this._onChange.bind(this);
-  }
-
-  componentDidMount() {
-    if (typeof M !== 'undefined') {
-      const { options } = this.props;
-      this.instance = M.Autocomplete.init(this._autocomplete, options);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.instance) {
-      this.instance.destroy();
-    }
-  }
-
-  renderIcon(icon) {
-    return React.cloneElement(icon, { className: 'prefix' });
-  }
-
-  _onChange(e) {
-    const { onChange } = this.props;
-    const value = e.target.value;
-
-    onChange && onChange(e, value);
-
-    this.setState({ value, itemSelected: false });
-  }
-
-  _onAutocomplete(value, e) {
-    const { onChange, options } = this.props;
-    const { onAutocomplete } = options;
-
-    onAutocomplete && onAutocomplete(value);
-
-    onChange && onChange(e, value);
-
-    this.setState({ value, itemSelected: true });
-  }
-
-  render() {
-    const {
-      id,
-      className,
-      title,
-      icon,
-      s,
-      m,
-      l,
-      xl,
-      offset,
-      placeholder,
-      // these are mentioned here only to prevent from getting into ...props
-      value,
-      onChange,
-      options,
-      ...props
-    } = this.props;
-
-    const _id = id || `autocomplete-${idgen()}`;
-    const sizes = { s, m, l, xl };
-    let classes = {
-      col: true
-    };
-    constants.SIZES.forEach(size => {
-      classes[size + sizes[size]] = sizes[size];
-    });
-
-    return (
-      <div
-        offset={offset}
-        className={cx('input-field', className, classes)}
-        {...props}
-      >
-        {icon && this.renderIcon(icon)}
-        <input
-          placeholder={placeholder}
-          className="autocomplete"
-          id={_id}
-          onChange={this._onChange}
-          type="text"
-          value={this.state.value}
-          ref={input => {
-            this._autocomplete = input;
-          }}
-        />
-        <label htmlFor={_id}>{title}</label>
-      </div>
-    );
-  }
-}
+  return (
+    <div
+      offset={offset}
+      className={cx('input-field', className, classes)}
+      {...props}
+    >
+      {icon && renderIcon(icon)}
+      <input
+        placeholder={placeholder}
+        className="autocomplete"
+        id={id}
+        onChange={onChange}
+        type="text"
+        ref={_autocomplete}
+      />
+      <label htmlFor={id}>{title}</label>
+    </div>
+  );
+};
 
 Autocomplete.propTypes = {
   /**
@@ -169,6 +124,7 @@ Autocomplete.propTypes = {
 };
 
 Autocomplete.defaultProps = {
+  id: `autocomplete_${idgen()}`,
   options: {
     data: {},
     limit: Infinity,

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Autocomplete from '../src/Autocomplete';
 import Icon from '../src/Icon';
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { text, withKnobs, object } from '@storybook/addon-knobs';
 
 const stories = storiesOf('Javascript|Autocomplete', module);
 stories.addDecorator(withKnobs);
@@ -16,11 +16,11 @@ stories.add(
   () => (
     <Autocomplete
       options={{
-        data: {
+        data: object('Data', {
           ['Gus Fring']: null,
           ['Saul Goodman']: null,
           ['Tuco Salamanca']: 'https://placehold.it/250x250'
-        }
+        })
       }}
       placeholder="Insert here"
     />
@@ -33,11 +33,11 @@ stories.add(
   () => (
     <Autocomplete
       options={{
-        data: {
+        data: object('Data', {
           ['Gus Fring']: null,
           ['Saul Goodman']: null,
           ['Tuco Salamanca']: 'https://placehold.it/250x250'
-        }
+        })
       }}
       placeholder="Insert here"
       icon={<Icon>{text('icon', 'textsms')}</Icon>}

--- a/test/__snapshots__/Autocomplete.spec.js.snap
+++ b/test/__snapshots__/Autocomplete.spec.js.snap
@@ -7,9 +7,7 @@ exports[`<Autocomplete /> renders 1`] = `
   <input
     className="autocomplete"
     id="testAutocompleteId"
-    onChange={[Function]}
     type="text"
-    value=""
   />
   <label
     htmlFor="testAutocompleteId"


### PR DESCRIPTION
# Description

Part of #928 

We might want to kill two birds with one stone and close #907 as well.

I left a comment there, let me know what do you want to do.

## Type of change

As `react-materialize` is a wrapper around `materialize` one should not rely on `onChange` when clicking on an `Autocomplete` suggestion.
For this, you should use `onAutocomplete`  `callback` that can be defined in `options`.
Moreover, having `onChange` returning the value instead of the `Synthetic Event` was really strange and not a thing that one expected (not me at least).

For these reasons, this is a breaking change.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Update `snapshot`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
