### PR TITLE
Dropdown: use hooks

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,74 +1,56 @@
-import React, { Component, Fragment, Children, cloneElement } from 'react';
+import React, {
+  Fragment,
+  Children,
+  cloneElement,
+  useRef,
+  useEffect
+} from 'react';
 import PropTypes from 'prop-types';
 import idgen from './idgen';
 import cx from 'classnames';
 
-class Dropdown extends Component {
-  constructor(props) {
-    super(props);
-    this.idx = props.id || `dropdown${idgen()}`;
-    this.renderTrigger = this.renderTrigger.bind(this);
-    this.renderItems = this.renderItems.bind(this);
-  }
+const Dropdown = ({ children, className, trigger, options, ...props }) => {
+  const _dropdownContent = useRef(null);
 
-  componentDidMount() {
-    const { options } = this.props;
-
-    if (typeof M !== undefined) {
-      this.instance = M.Dropdown.init(
-        document.querySelectorAll(this._trigger),
-        options
-      )[0];
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.instance) {
-      this.instance.destroy();
-    }
-  }
-
-  render() {
-    const { className, ...props } = this.props;
-    delete props.trigger;
-    delete props.options;
-
-    return (
-      <Fragment>
-        {this.renderTrigger()}
-        <ul
-          {...props}
-          className={cx('dropdown-content', className)}
-          id={this.idx}
-        >
-          {this.renderItems()}
-        </ul>
-      </Fragment>
+  useEffect(() => {
+    const instance = M.Dropdown.init(
+      document.querySelector(`[data-target="${props.id}"]`),
+      options
     );
-  }
 
-  renderTrigger() {
-    const { trigger } = this.props;
+    return () => {
+      instance && instance.destroy();
+    };
+  }, [options, props.id]);
 
-    return cloneElement(trigger, {
-      'data-target': this.idx,
-      ref: t => (this._trigger = `[data-target=${this.idx}]`),
+  const renderTrigger = () =>
+    cloneElement(trigger, {
+      'data-target': props.id,
       className: cx(trigger.props.className, 'dropdown-trigger')
     });
-  }
 
-  renderItems() {
-    const { children } = this.props;
-
-    return Children.map(children, element => {
+  const renderItems = () =>
+    Children.map(children, element => {
       if (element.type.name === 'Divider') {
         return <li key={idgen()} className="divider" tabIndex="-1" />;
       } else {
         return <li key={idgen()}>{element}</li>;
       }
     });
-  }
-}
+
+  return (
+    <Fragment>
+      {renderTrigger()}
+      <ul
+        {...props}
+        className={cx('dropdown-content', className)}
+        ref={_dropdownContent}
+      >
+        {renderItems()}
+      </ul>
+    </Fragment>
+  );
+};
 
 Dropdown.propTypes = {
   id: PropTypes.string,
@@ -101,6 +83,7 @@ Dropdown.propTypes = {
 };
 
 Dropdown.defaultProps = {
+  id: `dropdown_${idgen()}`,
   options: {
     alignment: 'left',
     autoTrigger: true,

--- a/test/DropdownButton.spec.js
+++ b/test/DropdownButton.spec.js
@@ -12,13 +12,6 @@ describe('<Dropdown />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  // test('does not update ID reference with each render', () => {
-  //   wrapper = shallow(<Dropdown trigger={<span>hi</span>} />);
-  //   const { id } = wrapper.instance();
-  //   wrapper.render();
-  //   expect(wrapper.instance().id).toEqual(id);
-  // });
-
   test('does correctly render dividers', () => {
     wrapper = shallow(
       <Dropdown trigger={<span>hi</span>}>

--- a/test/DropdownButton.spec.js
+++ b/test/DropdownButton.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Dropdown from '../src/Dropdown';
 import Divider from '../src/Divider';
 import mocker from './helper/new-mocker';
@@ -12,12 +12,12 @@ describe('<Dropdown />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  test('does not update ID reference with each render', () => {
-    wrapper = shallow(<Dropdown trigger={<span>hi</span>} />);
-    const { idx } = wrapper.instance();
-    wrapper.render();
-    expect(wrapper.instance().idx).toEqual(idx);
-  });
+  // test('does not update ID reference with each render', () => {
+  //   wrapper = shallow(<Dropdown trigger={<span>hi</span>} />);
+  //   const { id } = wrapper.instance();
+  //   wrapper.render();
+  //   expect(wrapper.instance().id).toEqual(id);
+  // });
 
   test('does correctly render dividers', () => {
     wrapper = shallow(
@@ -43,7 +43,7 @@ describe('<Dropdown />', () => {
     const dropdownMock = {
       init: (el, options) => {
         dropdownInitMock(options);
-        return [{ destroy: dropdownInstanceDestroyMock }];
+        return { destroy: dropdownInstanceDestroyMock };
       }
     };
 
@@ -59,7 +59,7 @@ describe('<Dropdown />', () => {
     });
 
     test('with default options if none are given', () => {
-      wrapper = shallow(<Dropdown trigger={<button>Drop me!</button>} />);
+      wrapper = mount(<Dropdown trigger={<button>Drop me!</button>} />);
       expect(dropdownInitMock).toHaveBeenCalledWith({
         alignment: 'left',
         autoTrigger: true,
@@ -79,7 +79,7 @@ describe('<Dropdown />', () => {
 
     test('handles options prop', () => {
       const options = { constrainWidth: true };
-      wrapper = shallow(
+      wrapper = mount(
         <Dropdown trigger={<button>Drop me!</button>} options={options} />
       );
       expect(dropdownInitMock).toHaveBeenCalledWith(options);
@@ -87,7 +87,7 @@ describe('<Dropdown />', () => {
 
     test('should destroy when unmounted', () => {
       const options = { constrainWidth: true };
-      wrapper = shallow(
+      wrapper = mount(
         <Dropdown trigger={<button>Drop me!</button>} options={options} />
       );
       wrapper.unmount();

--- a/test/__snapshots__/DropdownButton.spec.js.snap
+++ b/test/__snapshots__/DropdownButton.spec.js.snap
@@ -4,13 +4,13 @@ exports[`<Dropdown /> renders 1`] = `
 <Fragment>
   <button
     className="dropdown-trigger"
-    data-target="dropdownmockId"
+    data-target="dropdown_mockId"
   >
     Drop me!
   </button>
   <ul
     className="dropdown-content"
-    id="dropdownmockId"
+    id="dropdown_mockId"
   />
 </Fragment>
 `;


### PR DESCRIPTION
# Description

Part of #928

# How Has This Been Tested?

The only test failing at this moment is the following one:

```js
  test('does not update ID reference with each render', () => {
    wrapper = shallow(<Dropdown trigger={<span>hi</span>} />);
    const { id } = wrapper.instance();
    wrapper.render();
    expect(wrapper.instance().id).toEqual(id);
  });
```

Citing [Enzyme documentation](https://airbnb.io/enzyme/docs/api/ShallowWrapper/instance.html#instance--reactcomponent):

> NOTE: can only be called on a wrapper instance that is also the root instance. With React 16 and above, instance() returns null for stateless functional components.

Anyway, I do not think this test is useful anymore, as `idx` has been removed.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
