### PR TITLE
fix: remove waves effect when button is disabled

### DIFF
--- a/src/PaginationButton.js
+++ b/src/PaginationButton.js
@@ -11,7 +11,7 @@ const PaginationButton = ({
   onSelect
 }) => {
   const classes = {
-    'waves-effect': true,
+    'waves-effect': !disabled,
     disabled,
     active
   };


### PR DESCRIPTION
# Description

As per the [`materialize-css` example page](https://materializecss.com/pagination.html#!), disabled buttons do not have `waves`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Currently, there is no `spec` for this component.
We might want to add at least one to check if setting `disabled` `prop` to true actually removes the `waves-effect` `css` class.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
