### PR TITLE
Fix Card with revealIcon

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -15,7 +15,6 @@ class Card extends Component {
 
   renderTitle(title, reveal) {
     const { revealIcon } = this.props;
-
     return (
       <span
         className={cx('card-title', {
@@ -23,7 +22,7 @@ class Card extends Component {
         })}
       >
         {title}
-        {reveal && { revealIcon }}
+        {reveal && revealIcon}
       </span>
     );
   }
@@ -77,6 +76,9 @@ class Card extends Component {
       horizontal,
       ...other
     } = this.props;
+
+    delete other.revealIcon;
+    delete other.closeIcon;
 
     const classes = {
       card: true,

--- a/src/CardTitle.js
+++ b/src/CardTitle.js
@@ -13,7 +13,6 @@ class CardTitle extends Component {
       'waves-block': waves,
       [`waves-${waves}`]: waves
     });
-
     return (
       <div className={cx(classes)} {...props}>
         <img className={cx({ activator: reveal })} src={image} />

--- a/test/__snapshots__/Card.spec.js.snap
+++ b/test/__snapshots__/Card.spec.js.snap
@@ -3,16 +3,6 @@
 exports[`<Card /> renders 1`] = `
 <div
   className="blue-grey darken-1 card"
-  closeIcon={
-    <Icon>
-      close
-    </Icon>
-  }
-  revealIcon={
-    <Icon>
-      more_vert
-    </Icon>
-  }
 >
   <div
     className="card-content white-text"


### PR DESCRIPTION
# Description

This PR fixes the issue #977 where some issues are beign caused because of the wrong injection of some props.

The `Card` component has two props that was beign injected in a `div` and it's causing the console warning.
`closeIcon` and `revealIcon` isn't valid attributes to a `div` tag. Those props are being injected using the spread technique. 
Those props aren't used in the render scenario, and this was the motivation to use the `delete` way to handle it.

Also was fixed an issue in the code where the `revealIcon` was evaluated as an object. The component was not working correctly and was fixed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Open the storybook you see the first issue with the invalid `object` in the DOM.
Having storybook opened and chrome devtools console you can see the warning about the invalid props.
Digging into the DOM tree you see the two invalid attributes `revealicon & closeicon` what makes the errors appears.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
