### PR TITLE
Fix undefined check

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -14,7 +14,7 @@ class Dropdown extends Component {
   componentDidMount() {
     const { options } = this.props;
 
-    if (typeof M !== undefined) {
+    if (typeof M !== 'undefined') {
       this.instance = M.Dropdown.init(
         document.querySelectorAll(this._trigger),
         options

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -61,7 +61,7 @@ class Dropdown extends Component {
     const { children } = this.props;
 
     return Children.map(children, element => {
-      if (element.type.name === 'Divider') {
+      if (element && element.type.name === 'Divider') {
         return <li key={idgen()} className="divider" tabIndex="-1" />;
       } else {
         return <li key={idgen()}>{element}</li>;


### PR DESCRIPTION
# Description

Dropdown was throwing because it was trying to invoke a method on `M` when `M` was undefined. Components don't work as expected without the `M` global defined. This should be added to the documentation:

`window.M = require('materialize-css')`

Without that, things like dropdowns don't work.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


