### PR TITLE
Support false/null elements in Dropdown

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -61,10 +61,12 @@ class Dropdown extends Component {
     const { children } = this.props;
 
     return Children.map(children, element => {
-      if (element.type.name === 'Divider') {
-        return <li key={idgen()} className="divider" tabIndex="-1" />;
-      } else {
-        return <li key={idgen()}>{element}</li>;
+      if (element) {
+        if (element.type.name === 'Divider') {
+          return <li key={idgen()} className="divider" tabIndex="-1" />;
+        } else {
+          return <li key={idgen()}>{element}</li>;
+        }
       }
     });
   }


### PR DESCRIPTION
# Description

Dropdown was failing to support null/false elements due to an incompatible type check. The check was not checking if an element existed before inspecting `element.type.name`. Standard elements have a type of "a", so the check was passing, but null elements don't have a type therefore need to have a truthy check before inspecting.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

