### PR TITLE
github actions: dont fail if not published

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -38,5 +38,6 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish
+        continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description

not always when merged to master do we want to create a new npm version, this allows publish to npm job to fail silently