### PR TITLE
Modal document fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@ globals:
   global: true
   window: true
   module: true
-  Element: true
+  console: true
 
 plugins: ['prettier', 'react-hooks']
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.8.6
+
+- Modal: add warning and failsafe for root prop
+
 ### 3.8.5
 
 - Modal: fix renrendering bug

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -28,6 +28,11 @@ const Modal = ({
   const _modalRoot = useRef(null);
   const _modalInstance = useRef(null);
   const _modalRef = useRef(null);
+  if (root === null) {
+    console.warn(
+      'React Materialize: root should be a valid node element to render a Modal'
+    );
+  }
 
   useEffect(() => {
     const modalRoot = _modalRoot.current;
@@ -194,7 +199,7 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   id: `Modal-${idgen()}`,
-  root: document.body,
+  root: typeof window !== undefined ? document.body : null,
   open: false,
   options: {
     opacity: 0.5,


### PR DESCRIPTION
Fixes Modal breaking when no `window.document` exists, like in Gatsby and Nextjs

ref: #1106