### PR TITLE
3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.9.1
+
+- Modal: remove children from dependency
+
 ### 3.9.0
 
 - JS: add children as dependency for JS components

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -42,7 +42,7 @@ const Modal = ({
       root.removeChild(modalRoot);
       _modalInstance.current.destroy();
     };
-  }, [options, root, children]);
+  }, [options, root]);
 
   useEffect(() => {
     if (open) {


### PR DESCRIPTION
Fixes #1123

`Modal` should not reinitialise when children change (due to state change for example)