### PR TITLE
Modal compare options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.9.2
+
+- Modal: deep compare options dependency
+
 ### 3.9.1
 
 - Modal: remove children from dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-materialize",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Material design components for react",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -11,6 +11,7 @@ import cx from 'classnames';
 
 import idgen from './idgen';
 import Button from './Button';
+import { safeJSONStringify } from './utils';
 
 const Modal = ({
   actions,
@@ -36,13 +37,19 @@ const Modal = ({
 
   useEffect(() => {
     const modalRoot = _modalRoot.current;
-    _modalInstance.current = M.Modal.init(_modalRef.current, options);
+    if (!_modalInstance.current) {
+      _modalInstance.current = M.Modal.init(_modalRef.current, options);
+    }
 
     return () => {
-      root.removeChild(modalRoot);
+      if (root.contains(modalRoot)) {
+        root.removeChild(modalRoot);
+      }
       _modalInstance.current.destroy();
     };
-  }, [options, root]);
+    // deep comparing options object
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safeJSONStringify(options), root]);
 
   useEffect(() => {
     if (open) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,8 @@
+export const safeJSONStringify = s => {
+  try {
+    return JSON.stringify(s);
+  } catch (err) {
+    console.error(err);
+    return NaN;
+  }
+};


### PR DESCRIPTION
Fixes #1123

Previoulsy when rerendering the Modal with options supplied, these were considered NEW in each render, therefor reinitializing the Modal.

With JSON.stringify we can deep compare the options and save rerenders.