### PR TITLE
Update link to Material Icons from http to https (storybook)

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,2 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet" type="text/css" media="screen"/>
-<link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
# Description

The link to the Material Icons `preview-head.html` refers to the HTTP url, which won't be loaded when browsing to the documentation over HTTPS for [the Icon component](https://react-materialize.github.io/react-materialize/?path=/story/components-icons--default). The example Icon will thus not be shown. I found the same issue on the documentation page for [the Accordion component](https://react-materialize.github.io/react-materialize/?path=/story/javascript-collapsible--accordion) for example.

![Icon documentation](https://user-images.githubusercontent.com/5738744/83412232-09476400-a41a-11ea-8cb1-aedf5a6c0043.png)


## Type of change

Please delete options that are not relevant.
- [X] This change requires a documentation update

# How Has This Been Tested?
Executed `npm run build-storybook && npm run storybook` and opened the Icon page locally to verify that the Material Icons were fetched over HTTPS: 
![https](https://user-images.githubusercontent.com/5738744/83412598-ad310f80-a41a-11ea-9302-35a3443d91b3.png)

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
