### PR TITLE
allows style props with typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3280,9 +3280,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {
@@ -5463,8 +5463,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "resolved": "",
           "dev": true
         }
       }
@@ -7517,8 +7516,7 @@
     "csstype": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
-      "dev": true
+      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -14589,9 +14587,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.1.tgz",
-      "integrity": "sha512-FdtDAv8d9/tjyHxdCvWZxxOgK2icwzBkTq/dPk+XlQ2B+DYDcwE89FWGzT92erXQ0CQR/bQbpNK3loNYhYL70g==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.2",
@@ -19487,8 +19485,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "resolved": "",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "classnames": "^2.2.6"
+    "classnames": "^2.2.6",
+    "csstype": "^2.6.10"
   }
 }

--- a/types/components/utils.d.ts
+++ b/types/components/utils.d.ts
@@ -1,3 +1,4 @@
+import CSS from 'csstype';
 export interface Responsive {
   s?: number;
   m?: number;
@@ -11,6 +12,7 @@ export type AnyFn = (...args: any[]) => any;
 export interface SharedBasic {
   className?: string;
   children?: React.ReactNode;
+  style?: CSS.Properties;
 }
 
 export type MaterialColor =


### PR DESCRIPTION
# Description

Updates your typescript utils.d.ts file to allow the style props for components, for example
```<Button style={{backgroundColor: '#FF8C00'}}>Click Me</Button>```
has typescript error currently

## Type of change
* installed csstype package, then found found 621 vulnerabilities
* ran `npm audit fix`
* made change to utils.d.ts


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added to my own project that is using react-materialize and not longer have typescript error

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have not generated a new package version. (the maintainers will handle that)
