### PR TITLE
removes not needed dependency as it is already in React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7516,7 +7516,8 @@
     "csstype": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
+      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "classnames": "^2.2.6",
-    "csstype": "^2.6.10"
+    "classnames": "^2.2.6"
   }
 }

--- a/types/components/utils.d.ts
+++ b/types/components/utils.d.ts
@@ -1,4 +1,3 @@
-import CSS from 'csstype';
 export interface Responsive {
   s?: number;
   m?: number;
@@ -12,7 +11,7 @@ export type AnyFn = (...args: any[]) => any;
 export interface SharedBasic {
   className?: string;
   children?: React.ReactNode;
-  style?: CSS.Properties;
+  style?: React.CSSProperties;
 }
 
 export type MaterialColor =


### PR DESCRIPTION
This fixes merge https://github.com/react-materialize/react-materialize/commit/77d509dc28a3e1b4642e79048ce9e06e062f8968

Someone smarter than me said that the type for react style prop was already in React.
