### PR TITLE
Add 'id' parameter to RadioGroup to fix issue #989

### DIFF
--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -9,18 +9,21 @@ const RadioGroup = ({
   name,
   radioClassNames,
   value,
-  options
+  options,
+  id
 }) => {
+  // Generates unique radio-ids if an 'id' is provided to fix issue #989
+  const idPrefex = typeof id === 'undefined' ? `` : `RadioGroup_${id}_`;
   return (
     <React.Fragment>
       {options.map((radioItem, idx) => (
         <label
           className={radioClassNames}
-          htmlFor={`radio${idx}`}
-          key={`radio${idx}`}
+          htmlFor={`${idPrefex}radio${idx}`}
+          key={`${idPrefex}radio${idx}`}
         >
           <input
-            id={`radio${idx}`}
+            id={`${idPrefex}radio${idx}`}
             value={radioItem.value}
             type="radio"
             checked={radioItem.value === value}
@@ -66,7 +69,11 @@ RadioGroup.propTypes = {
   /**
    * classnames passed to label wrapper
    */
-  radioClassNames: PropTypes.string
+  radioClassNames: PropTypes.string,
+  /**
+   * to generate unique radio-ids for different RadioGroups if provided
+   */
+  id: PropTypes.string
 };
 
 export default RadioGroup;

--- a/test/RadioGroup.spec.js
+++ b/test/RadioGroup.spec.js
@@ -42,10 +42,19 @@ describe('<RadioGroup />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  test('onChange callback', () => {
+  test('onChange callback without id parameter', () => {
     wrapper = shallow(<RadioGroup {...defaultProps} />);
     wrapper
-      .find('input')
+      .find('#radio0')
+      .first()
+      .simulate('change');
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  test('onChange callback with id parameter', () => {
+    wrapper = shallow(<RadioGroup {...defaultProps} id="shirtSize" />);
+    wrapper
+      .find('#RadioGroup_shirtSize_radio0')
       .first()
       .simulate('change');
     expect(mockOnChange).toHaveBeenCalled();

--- a/types/components/RadioGroup.d.ts
+++ b/types/components/RadioGroup.d.ts
@@ -3,6 +3,7 @@ import * as React from "react";
 export interface RadioGroupProps {
   label?: string;
   name?: string;
+  id?: string;
   options: Array<{ label: string; value: string }>;
   value?: string;
   withGap?: boolean;


### PR DESCRIPTION
# Description

This is a very simply approach to fix the issue #989 .
* Currently the `id`s of each radio `<input>` are named as follows: `radio0`, `radio1`, ...
* Because of this the `id`s of different `<RadioGroup>`s are non-unique
* Thus, the `onChange` handler of the first `<RadioGroup>`  is always called, also when a second group was added and clicked

With this PR the `radio` `id`s get unique names, based on a provided `id`-parameter:
* without `id` parameter in the `<RadioGroup>` the `id`s names are still generated as before (backward-compatibility)
* with `id` parameter in the `<RadioGroup>` the `id`s between multiple groups are unique: `RadioGroup_${id}_radio0`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

1. All tests run through: `npm test a`.
2. Backward-compatibility is ensured: The existing test case `onChange callback` in `RadioGroup.spec.js` was adjusted to fail if the ids are not generated as before.
3. Added a second test case `onChange callback with id parameter` which makes sure a provided `id` parameter is used to generate a unique ids.
4. I added the altered version of the `RadioGroup` component to my own project were I had the issue #989.
With the new `RadioGroup` component and after adding the `id` parameter to the RadioGroups the issue #989 is fixed:
```
<RadioGroup
          id="groupA"
          withGap
          name="groupA"
          label="Group A"
          options={[
            {
              label: 'Option 1',
              value: 'option1'
            },
            {
              label: 'Option 2',
              value: 'option2'
            }
          ]}
          onChange={this.testHandlerA}
        /><br /><br /><br />

        <RadioGroup
          id="groupB"
          withGap
          name="groupB"
          label="Group B"
          options={[
            {
              label: 'Option 1b',
              value: '1b'
            },
            {
              label: 'Option 2b',
              value: '2b'
            }
          ]}
          onChange={this.testHandlerB}
        />
```

i.e. clicking on ` 'Option 2b',` now triggers `testHandlerB` with the correct `event.target`.
Before the `testHandlerA` was called with `option2` as event.target.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
