### PR TITLE
Add missing props to Select type

### DIFF
--- a/types/components/Select.d.ts
+++ b/types/components/Select.d.ts
@@ -16,6 +16,13 @@ export interface SelectProps extends Responsive, SharedBasic {
   options?: SelectOptions;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  noLayout?: boolean;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  validate?: boolean;
+  success?: string;
+  error?: string;
+  browserDefault?: boolean;
 }
 
 /**


### PR DESCRIPTION
Typescript declaration for Select control where missing some properties. 
This adds those missing once:
```ts
  noLayout?: boolean;
  disabled?: boolean;
  icon?: React.ReactNode;
  validate?: boolean;
  success?: string;
  error?: string;
  browserDefault?: boolean;
```