### PR TITLE
Preloader fix size class name

### DIFF
--- a/src/Preloader.js
+++ b/src/Preloader.js
@@ -7,7 +7,7 @@ import Spinner from './Spinner';
 const colors = ['blue', 'red', 'yellow', 'green'];
 
 const Preloader = ({ active, size, color, flashing, className }) => {
-  let classes = cx('preloader-wrapper', { active, size });
+  let classes = cx('preloader-wrapper', { active }, size);
 
   let spinners;
   if (flashing) {


### PR DESCRIPTION
Preloader component applied invalid size class name.
It was always "*size*" instead of the value of the `size` property.
This fixes this issue and uses the correct value.