### PR TITLE
Fix Spinner not exported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ export { default as SideNav } from './SideNav';
 export { default as SideNavItem } from './SideNavItem';
 export { default as Slide } from './Slide';
 export { default as Slider } from './Slider';
+export { default as Spinner } from './Spinner';
 export { default as Switch } from './Switch';
 export { default as Tab } from './Tab';
 export { default as Table } from './Table';


### PR DESCRIPTION
This exports the Spinner component as it is already exported in the typescript definitions.
