### PR TITLE
Fix href requirement in CollectionItem's typings

### DIFF
--- a/types/components/CollectionItem.d.ts
+++ b/types/components/CollectionItem.d.ts
@@ -3,7 +3,7 @@ import { SharedBasic } from './utils';
 
 export interface CollectionItemProps extends SharedBasic {
   active?: boolean;
-  href: string;
+  href?: string;
 }
 
 /**


### PR DESCRIPTION
# Description

Fixes `href` attribute being required in `CollectionItem`'s TypeScript typings.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No tests for typings as far as I can tell.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
