### PR TITLE
fix: call updateTextFields on AutoComplete so label doesn't overlap

### DIFF
--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -26,6 +26,7 @@ const Autocomplete = ({
   });
 
   useEffect(() => {
+    M.updateTextFields();
     const instance = M.Autocomplete.init(autocompleteRef.current, options);
 
     return () => {

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -22,7 +22,7 @@ stories.add(
           ['Tuco Salamanca']: 'https://placehold.it/250x250'
         })
       }}
-      placeholder="Insert here"
+      placeholder={text('placeholder', 'Insert here')}
     />
   ),
   { notes }
@@ -39,8 +39,26 @@ stories.add(
           ['Tuco Salamanca']: 'https://placehold.it/250x250'
         })
       }}
-      placeholder="Insert here"
+      placeholder={text('placeholder', 'Insert here')}
       icon={<Icon>{text('icon', 'textsms')}</Icon>}
+    />
+  ),
+  { notes }
+);
+
+stories.add(
+  'With label',
+  () => (
+    <Autocomplete
+      options={{
+        data: object('Data', {
+          ['Gus Fring']: null,
+          ['Saul Goodman']: null,
+          ['Tuco Salamanca']: 'https://placehold.it/250x250'
+        })
+      }}
+      placeholder={text('placeholder', 'Insert here')}
+      title={text('label', 'Input Label')}
     />
   ),
   { notes }


### PR DESCRIPTION
# Description

Fixes #909 by calling `updateTextFields` on the AutoComplete component.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a new storybook story matching the code example from the issue (https://codesandbox.io/s/bold-herschel-xfd1j) and visually inspected the appearance of the label text.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
