### PR TITLE
fix: need to add 'invalid' class for errors to be displayed

### DIFF
--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -129,7 +129,7 @@ const TextInput = React.forwardRef((props, ref) => {
       {renderIcon()}
       <input
         ref={inputRef}
-        className={cx({ validate }, inputClassName)}
+        className={cx({ validate }, { invalid: error }, inputClassName)}
         {...inputProps}
       />
       {renderLabel()}

--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -59,7 +59,12 @@ const Textarea = ({
         ref={textareaRef}
         onChange={onChange}
         {...rest}
-        className={cx('materialize-textarea', { validate }, className)}
+        className={cx(
+          'materialize-textarea',
+          { validate },
+          { invalid: error },
+          className
+        )}
       />
       {Boolean(label) && (
         <label

--- a/stories/TextInput.stories.js
+++ b/stories/TextInput.stories.js
@@ -75,3 +75,18 @@ stories.add('with icon string', () => (
 stories.add('with icon node', () => (
   <TextInput icon={<Icon>{text('icon', 'email')}</Icon>} label="Email" />
 ));
+
+stories.add(
+  'with error message',
+  () => (
+    <TextInput
+      label="Custom Validation"
+      error={text('error', 'This is an error')}
+    />
+  ),
+  {
+    info: {
+      text: 'Displays a validation error.'
+    }
+  }
+);

--- a/stories/Textarea.stories.js
+++ b/stories/Textarea.stories.js
@@ -65,3 +65,13 @@ stories.add(
     }
   }
 );
+
+stories.add(
+  'Errors',
+  () => <Textarea label="Textarea" error={text('error', 'This is an error')} />,
+  {
+    info: {
+      text: 'Displays a validation error.'
+    }
+  }
+);

--- a/test/TextInput.spec.js
+++ b/test/TextInput.spec.js
@@ -62,6 +62,14 @@ describe('<TextInput />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  test('Displays error messages', () => {
+    wrapper = shallow(
+      <TextInput label="Input with Error" error="this is an error" />
+    );
+    expect(wrapper.find('input').hasClass('invalid')).toBeTruthy();
+    expect(wrapper).toMatchSnapshot();
+  });
+
   describe('Icon', () => {
     test('renders as a string', () => {
       wrapper = shallow(<TextInput icon="cloud" />);

--- a/test/Textarea.spec.js
+++ b/test/Textarea.spec.js
@@ -74,4 +74,12 @@ describe('<Textarea />', () => {
     textarea.simulate('change');
     expect(onChangeMock).toHaveBeenCalled();
   });
+
+  test('Displays error messages', () => {
+    wrapper = shallow(
+      <Textarea label="Input with Error" error="this is an error" />
+    );
+    expect(wrapper.find('textarea').hasClass('invalid')).toBeTruthy();
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/test/__snapshots__/TextInput.spec.js.snap
+++ b/test/__snapshots__/TextInput.spec.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<TextInput /> Displays error messages 1`] = `
+<div
+  className="input-field col"
+>
+  <input
+    className="invalid"
+    id="TextInput-mockId"
+    type="text"
+  />
+  <label
+    className=""
+    data-error="this is an error"
+    htmlFor="TextInput-mockId"
+  >
+    Input with Error
+  </label>
+  <span
+    className="helper-text"
+    data-error="this is an error"
+  />
+</div>
+`;
+
 exports[`<TextInput /> handles file type 1`] = `
 <div
   className="input-field col file-field"

--- a/test/__snapshots__/Textarea.spec.js.snap
+++ b/test/__snapshots__/Textarea.spec.js.snap
@@ -16,6 +16,28 @@ exports[`<Textarea /> Disabled 1`] = `
 </div>
 `;
 
+exports[`<Textarea /> Displays error messages 1`] = `
+<div
+  className="input-field col"
+>
+  <textarea
+    className="materialize-textarea invalid"
+    id="Textarea-mockId"
+  />
+  <label
+    className=""
+    data-error="this is an error"
+    htmlFor="Textarea-mockId"
+  >
+    Input with Error
+  </label>
+  <span
+    className="helper-text"
+    data-error="this is an error"
+  />
+</div>
+`;
+
 exports[`<Textarea /> Icon 1`] = `
 <div
   className="input-field col"

--- a/test/index.types.ts
+++ b/test/index.types.ts
@@ -1,0 +1,15 @@
+import {IconProps} from "../types/components";
+
+it('accepts style props', () => {
+    let props: IconProps  ={
+        className: "test",
+        left: true,
+        large: true,
+        style: {
+            fontSize: "30px"
+        },
+        onClick: ()=>undefined,
+        // Prop that isn't permitted
+        foo: ""
+    }
+})


### PR DESCRIPTION
# Description

Materialize will only display the error text on a form input if the `invalid` class is present on the underlying `input` element.  
Fixes #1132 for both`Textarea` and `TextInput`.  I'm not sure if there are other components where this fix should be applied.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Storybook stories were added to check the visual display of the error messages and new test cases added to the Textarea and TestInput specs to verify that the class is being added.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
