### PR TITLE
Allow Dropdown to accept null, li, and Divider children.

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -30,8 +30,13 @@ const Dropdown = ({ children, className, trigger, options, ...props }) => {
     });
 
   const renderItems = () =>
-    Children.map(children, element => {
-      if (element.type.name === 'Divider') {
+    Children.map(children.filter(Boolean), element => {
+      if (element.type === 'li') {
+        return element;
+      } else if (
+        element.type.name === 'Divider' ||
+        element.type.displayName === 'Divider'
+      ) {
         return <li key={idgen()} className="divider" tabIndex="-1" />;
       } else {
         return <li key={idgen()}>{element}</li>;

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -30,7 +30,7 @@ const Dropdown = ({ children, className, trigger, options, ...props }) => {
     });
 
   const renderItems = () =>
-    Children.map(children.filter(Boolean), element => {
+    Children.map((children || []).filter(Boolean), element => {
       if (element.type === 'li') {
         return element;
       } else if (


### PR DESCRIPTION
# Description

This change allows the `<Dropdown/>` component to accept `null` and `li` items, as well as fixes rendering of dropdowns in minified builds (per #993).

Accepting `null` items allows for conditional item semantics, such as:

```jsx
const isActive = false;
<Dropdown>
  { isActive && <a href={'...'}>Deactivate</a> }
  <li>
    <a>Do not wrap this li</a>
  </li>
  <Divider />{/* <-- now renders without an LI in minified code */}
</Dropdown>
```

Prior to this change, `null` children are not excluded from processing, and raise errors inside the Dropdown component.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Minimal viable example is provided above, code change is trivial and has been tested in minified code builds.

# Checklist:

- [?] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have not generated a new package version. (the maintainers will handle that)
