### PR TITLE
Make onSelect on CollapsibleItem optional (TypeScript)

### DIFF
--- a/types/components/CollapsibleItem.d.ts
+++ b/types/components/CollapsibleItem.d.ts
@@ -7,7 +7,7 @@ export interface CollapsibleItemProps extends SharedBasic {
   header: any;
   icon?: React.ReactNode;
   iconClassName?: string;
-  onSelect: (eventKey: any) => any;
+  onSelect?: (eventKey: any) => any;
   eventKey?: any;
 }
 


### PR DESCRIPTION
This change partially reverts the changes made in 4308d86fbc99e28eaff7d676c44a18d1c823be6d, which made `onSelect` on `CollapsibleItem` mandatory.

# Description

`onSelect` should not be a mandatory prop of `CollapsibleItem`. [Existing documentation do not use the prop](http://react-materialize.github.io/react-materialize/?path=/story/javascript-collapsible--popout), and not including it flags a type error.

![image](https://user-images.githubusercontent.com/13886925/103718390-880f0b80-4fbe-11eb-8017-bfa7600a22d5.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Cloned and built whilst checking that the build process emits `onSelect?: (eventKey: any) => any;` into the `CollapsibleItem.d.ts` file.
Also checked the typing error no longer occurs.

![image](https://user-images.githubusercontent.com/13886925/103719335-b42b8c00-4fc0-11eb-9be4-fbc9351f20dd.png)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)

This change (probably) does not warrant any commenting.
