### PR TITLE
fix: Flatten folder while copying TypeScript declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "build-storybook": "rm -rf docs && build-storybook -c .storybook -o docs",
     "build": "babel src --out-dir lib && npm run copy-types",
-    "copy-types": "copyfiles types/components/*.d.ts lib",
+    "copy-types": "copyfiles -f types/components/*.d.ts lib",
     "lint": "eslint src test",
     "fix": "eslint src test --fix",
     "release": "npm run build && npm publish",


### PR DESCRIPTION
# Description
This change fixes a regression caused by the `copyfiles` npm package while copying TypeScript declaration files.
Currently, the TypeScript files are in the wrong place, causing build errors.

![image](https://user-images.githubusercontent.com/13886925/104373984-1896a000-5519-11eb-807a-6fdfe047f769.png)

This adds the correct `-f` flatten flag to make sure the files are back where they used to be.

![image](https://user-images.githubusercontent.com/13886925/104373413-77a7e500-5518-11eb-8932-7997054e3cd5.png)

For a quick temporary fix before this PR is accepted, install the previous version: `react-materialize@3.9.5`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have built this on my own computer, and the `.d.ts` are next to the `.js` files as they should be

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
