### PR TITLE
fix: Include optional ref prop on TextInput

### DIFF
--- a/types/components/TextInput.d.ts
+++ b/types/components/TextInput.d.ts
@@ -20,6 +20,7 @@ export interface TextInputProps extends Responsive {
   email?: boolean;
   children?: React.ReactNode;
   name?: string;
+  ref?: React.RefObject<HTMLInputElement>;
 }
 
 /**


### PR DESCRIPTION
# Description

Fixes #1176 where consumers, in a TypeScript project, want to forward a reference to a `TextInput` but there's no such prop in the interface. 

Typically this should be an optional prop. This PR implements that.

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I linked my fork of `react-materialize` on a TypeScript project, and was able to compile when passing a `ref`, without labeling with `// @ts-expect-error`.

# Checklist:

- [ x ] My changes generate no new warnings
- [ x ] I have not generated a new package version. (the maintainers will handle that)
