### PR TITLE
Avoid duplicate IDs

### DIFF
--- a/src/Autocomplete.js
+++ b/src/Autocomplete.js
@@ -113,7 +113,9 @@ Autocomplete.propTypes = {
 };
 
 Autocomplete.defaultProps = {
-  id: `Autocomplete-${idgen()}`,
+  get id() {
+    return `Autocomplete-${idgen()}`;
+  },
   options: {
     data: {},
     limit: Infinity,

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -123,7 +123,9 @@ Carousel.propTypes = {
 };
 
 Carousel.defaultProps = {
-  carouselId: `Carousel-${idgen()}`,
+  get carouselId() {
+    return `Carousel-${idgen()}`;
+  },
   options: {
     duration: 200,
     dist: -100,

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -90,7 +90,9 @@ Checkbox.propTypes = {
 };
 
 Checkbox.defaultProps = {
-  id: `Checkbox_${idgen()}`
+  get id() {
+    return `Checkbox_-${idgen()}`;
+  }
 };
 
 export default Checkbox;

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -91,7 +91,7 @@ Checkbox.propTypes = {
 
 Checkbox.defaultProps = {
   get id() {
-    return `Checkbox_-${idgen()}`;
+    return `Checkbox_${idgen()}`;
   }
 };
 

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -157,7 +157,9 @@ DatePicker.propTypes = {
 };
 
 DatePicker.defaultProps = {
-  id: `DatePicker-${idgen()}`,
+  get id() {
+    return `DatePicker-${idgen()}`;
+  },
   options: {
     autoClose: false,
     format: 'mmm dd, yyyy',

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -96,7 +96,9 @@ Dropdown.propTypes = {
 };
 
 Dropdown.defaultProps = {
-  id: `Dropdown_${idgen()}`,
+  get id() {
+    return `Dropdown_${idgen()}`;
+  },
   options: {
     alignment: 'left',
     autoTrigger: true,

--- a/src/MediaBox.js
+++ b/src/MediaBox.js
@@ -67,7 +67,9 @@ MediaBox.propTypes = {
 };
 
 MediaBox.defaultProps = {
-  id: `MediaBox_${idgen()}`,
+  get id() {
+    return `MediaBox_${idgen()}`;
+  },
   options: {
     inDuration: 275,
     outDuration: 200,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -205,7 +205,9 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
-  id: `Modal-${idgen()}`,
+  get id() {
+    return `Modal-${idgen()}`;
+  },
   root: typeof window !== 'undefined' ? document.body : null,
   open: false,
   options: {

--- a/src/Select.js
+++ b/src/Select.js
@@ -195,7 +195,9 @@ Select.propTypes = {
 };
 
 Select.defaultProps = {
-  id: `Select-${idgen()}`,
+  get id() {
+    return `Select-${idgen()}`;
+  },
   multiple: false,
   options: {
     classes: '',

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -96,7 +96,9 @@ SideNav.propTypes = {
 };
 
 SideNav.defaultProps = {
-  id: `SideNav-${idgen()}`
+  get id() {
+    return `SideNav-${idgen()}`;
+  }
 };
 
 export default SideNav;

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -43,7 +43,9 @@ Switch.propTypes = {
 };
 
 Switch.defaultProps = {
-  id: `Switch-${idgen()}`,
+  get id() {
+    return `Switch-${idgen()}`;
+  },
   onChange: () => {}
 };
 

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -6,9 +6,14 @@ import cx from 'classnames';
 import Row from './Row';
 import Tab from './Tab';
 
-const scope = `tabs-${idgen()}`;
-
-const Tabs = ({ children, className, defaultValue, options, onChange }) => {
+const Tabs = ({
+  scope,
+  children,
+  className,
+  defaultValue,
+  options,
+  onChange
+}) => {
   const _tabsRef = useRef(null);
 
   useEffect(() => {
@@ -54,6 +59,11 @@ const Tabs = ({ children, className, defaultValue, options, onChange }) => {
 };
 
 Tabs.propTypes = {
+  /**
+   * Uniquely identifies each tab item
+   * @default idgen()
+   */
+  scope: PropTypes.string,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   defaultValue: PropTypes.string,
@@ -84,6 +94,12 @@ Tabs.propTypes = {
      */
     responsiveThreshold: PropTypes.number
   })
+};
+
+Tabs.defaultProps = {
+  get scope() {
+    return `tabs-${idgen()}`;
+  }
 };
 
 Tab.defaultProps = {

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -230,7 +230,9 @@ TextInput.propTypes = {
 };
 
 TextInput.defaultProps = {
-  id: `TextInput-${idgen()}`
+  get id() {
+    return `TextInput-${idgen()}`;
+  }
 };
 
 export default TextInput;

--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -164,7 +164,9 @@ Textarea.propTypes = {
 };
 
 Textarea.defaultProps = {
-  id: `Textarea-${idgen()}`
+  get id() {
+    return `Textarea-${idgen()}`;
+  }
 };
 
 export default Textarea;

--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -111,7 +111,9 @@ TimePicker.propTypes = {
 };
 
 TimePicker.defaultProps = {
-  id: `TimePicker-${idgen()}`,
+  get id() {
+    return `TimePicker-${idgen()}`;
+  },
   options: {
     duration: 350,
     container: null,


### PR DESCRIPTION
# Description

React will statically use the `defaultProps` object for all instances of the component. This means that duplicate IDs will be used. If we use a getter instead, the ID props will be dynamically generated by calling `idgen`.

Right now duplicate element IDs are being generated, this PR fixes it for all elements.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran unit tests and also used against the `css-update` branch of https://github.com/MicroPad/MicroPad-Core to verify the fix worked.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
