### PR TITLE
fix: Property 'type' does not exist on select tag

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -80,7 +80,6 @@ const Select = ({
       {Boolean(icon) && cloneElement(icon, { className: 'prefix' })}
       <select
         {...props}
-        type="select"
         id={id}
         value={selectedValue}
         ref={_selectRef}


### PR DESCRIPTION
# Description
Error message: Property 'type' does not exist on type 'DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>'. ts(2322)

Error doesn't show because of  {...props} spread before the type property.

Please include a summary of the change and which issue is fixed/what was added. Please also include relevant motivation and context.
removed unnecessary type property

## Type of change
fix

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
locally with work project

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have not generated a new package version. (the maintainers will handle that)
